### PR TITLE
[BUGFIX] Get back missing crdate in exports

### DIFF
--- a/Classes/DataExporter/DataExporter.php
+++ b/Classes/DataExporter/DataExporter.php
@@ -3,6 +3,7 @@
 namespace Frappant\FrpFormAnswers\DataExporter;
 
 use Frappant\FrpFormAnswers\Domain\Model\FormEntryDemand;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 class DataExporter
 {
@@ -18,6 +19,15 @@ class DataExporter
         $rows = array();
         $header = array();
         $headerKeys = (array)array_values($rowAnswers[0]->getAnswers());
+
+        // add header for crdate
+        $headerKeys[] = [
+            'value' => '',
+            'conf' => [
+                'label' => LocalizationUtility::translate('LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_db.xlf:tx_frpformanswers_domain_model_formentry.crdate'),
+                'inputType' => 'DateTime',
+            ],
+        ];
 
         $this->setHeaders($rowAnswers, $formEntryDemand, $headerKeys, $header);
 

--- a/Classes/View/FormEntry/ExportXml.php
+++ b/Classes/View/FormEntry/ExportXml.php
@@ -88,6 +88,10 @@ class ExportXml extends \TYPO3\CMS\Extbase\Mvc\View\AbstractView
 
         // put value in row
         foreach ($arr as $field => $value) {
+            // consider crdate
+            if ($value instanceof \DateTime) {
+                $value = $value->format('c');
+            }
             $str .= "\t\t<".$field.">".htmlspecialchars(stripslashes($value))."</".$field.">\n";
         }
 

--- a/Configuration/TCA/tx_frpformanswers_domain_model_formentry.php
+++ b/Configuration/TCA/tx_frpformanswers_domain_model_formentry.php
@@ -71,5 +71,16 @@ return [
                 'default' => 0
             ]
         ],
+        'crdate' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_db.xlf:tx_frpformanswers_domain_model_formentry.crdate',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'datetime',
+                'renderType' => 'InputDateTime',
+                'size' => 20,
+                'readOnly' => true,
+            ],
+        ],
     ],
 ];

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -21,6 +21,9 @@
 			<trans-unit id="tx_frpformanswers_domain_model_formentry.exported">
 				<source>Exported</source>
 			</trans-unit>
+			<trans-unit id="tx_frpformanswers_domain_model_formentry.crdate">
+				<source>Created on</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>


### PR DESCRIPTION
Crdate was exported as null, an explicit TCA definition brings it back
as DateTime object.

Also added a crdate header field with L10N entry to export.