### PR TITLE
[SECURITY] Upgrade phpoffice/phpspreadsheet to version 2.2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "https://frappant.ch",
     "require": {
         "typo3/cms-core": "^12.4",
-        "phpoffice/phpspreadsheet": "^1.22"
+        "phpoffice/phpspreadsheet": "^2.2"
     },
     "license": "GPL-2.0+",
     "autoload": {


### PR DESCRIPTION
This upgrade fix 2 security issues

* https://github.com/advisories/GHSA-ghg6-32f9-2jp7
* https://github.com/advisories/GHSA-wgmf-q9vr-vww6

see #74