### PR TITLE
[TASK] Add site set configuration

### DIFF
--- a/Configuration/Sets/FrpFormAnswers/config.yaml
+++ b/Configuration/Sets/FrpFormAnswers/config.yaml
@@ -1,0 +1,5 @@
+name: frappant/frp-form-answers
+label: 'Frappant Form Answers site set'
+
+dependencies:
+  - typo3/form

--- a/Configuration/Sets/FrpFormAnswers/constants.typoscript
+++ b/Configuration/Sets/FrpFormAnswers/constants.typoscript
@@ -1,0 +1,1 @@
+@import 'EXT:frp_form_answers/Configuration/TypoScript/constants.typoscript'

--- a/Configuration/Sets/FrpFormAnswers/page.tsconfig
+++ b/Configuration/Sets/FrpFormAnswers/page.tsconfig
@@ -1,0 +1,1 @@
+@import 'EXT:frp_form_answers/Configuration/TSconfig/Page/web_list.tsconfig'

--- a/Configuration/Sets/FrpFormAnswers/setup.typoscript
+++ b/Configuration/Sets/FrpFormAnswers/setup.typoscript
@@ -1,0 +1,2 @@
+@import 'EXT:frp_form_answers/Configuration/TypoScript/setupBe.typoscript'
+@import 'EXT:frp_form_answers/Configuration/TypoScript/setupFe.typoscript'

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "description": "Adds the possibility, as a finisher, to save and export the form entries from customers.",
     "homepage": "https://frappant.ch",
     "require": {
-        "typo3/cms-core": "^13.0",
+        "typo3/cms-core": "^13.1",
+		"typo3/cms-form": "^13.1",
         "phpoffice/phpspreadsheet": "^5.2.0"
     },
     "license": "GPL-2.0+",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -24,7 +24,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '6.1.2',
     'constraints' => [
         'depends' => [
-            'typo3' => '13.0.0-13.9.99',
+            'typo3' => '13.1.0-13.9.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
The extension can now be integrated into projects under TYPO3 v13 using Site Set.

For existing projects, the existing structure of TypoScript and PageTsConfig was not used for backward compatibility, so Site Sets are generally not mandatory.

Optional migration: Remove any `@import` statements in TypoScript for EXT:frp_form_answers. Add the site set `frappant/frp-form-answers` as a dependency in your site configuration.