### PR TITLE
[TASK] Fix CGL check and test on PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,13 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: true
+      fail-fast: false
 
       matrix:
         php:
           - '8.2'
           - '8.3'
+          - '8.4'
 
     steps:
       - name: 'Checkout'

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -398,9 +398,9 @@ fi
 case ${TEST_SUITE} in
     cgl)
         if [ "${CGLCHECK_DRY_RUN}" -eq 1 ]; then
-            COMMAND="php -dxdebug.mode=off .Build/bin/php-cs-fixer fix -v --dry-run --diff --config=Build/cgl/.php-cs-fixer.dist.php --using-cache=no ."
+            COMMAND="php -dxdebug.mode=off .Build/bin/php-cs-fixer fix -v --dry-run --diff --config=Build/cgl/.php-cs-fixer.dist.php --using-cache=no"
         else
-            COMMAND="php -dxdebug.mode=off .Build/bin/php-cs-fixer fix -v --config=Build/cgl/.php-cs-fixer.dist.php --using-cache=no ."
+            COMMAND="php -dxdebug.mode=off .Build/bin/php-cs-fixer fix -v --config=Build/cgl/.php-cs-fixer.dist.php --using-cache=no"
         fi
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name cgl-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?

--- a/Build/cgl/.php-cs-fixer.dist.php
+++ b/Build/cgl/.php-cs-fixer.dist.php
@@ -12,9 +12,10 @@ if (PHP_SAPI !== 'cli') {
 return (new Config())
     ->setFinder(
         (new Finder())
-            ->in(__DIR__ . '/../../')
-            ->exclude(__DIR__ . '/../../.Build')
-            ->exclude(__DIR__ . '/../../var')
+            ->in(dirname(__DIR__, 2))
+            // Finder::exclude() expects directory names relative to in(),
+            // absolute paths are silently ignored
+            ->exclude(['.Build', 'var', 'public', 'vendor'])
     )
     ->setRiskyAllowed(true)
     ->setRules([


### PR DESCRIPTION
The CGL job failed on master right after the 7.0.0 merge: https://github.com/frappant/frp_form_answers/actions/runs/32351973787

## Cause

`Finder::exclude()` expects directory names relative to `in()`; the config passed absolute paths, which are silently ignored. php-cs-fixer therefore scanned TYPO3's generated DI container under `var/cache/code/di/` and reported it as fixable (exit code 8).

## Changes

* `Build/cgl/.php-cs-fixer.dist.php`: exclude `.Build`, `var`, `public` and `vendor` by name.
* `.github/workflows/ci.yml`: add PHP 8.4 to the matrix (`runTests.sh` and all dev tools already support it) and set `fail-fast: false` so one PHP version failing no longer cancels the others.

## Verification

Reproduced locally with a seeded `var/cache/code/di/` file: old config reports 2 fixable of 37 scanned files, new config 0 of 35. Full gate run on PHP 8.4 — PHPUnit 7/7, PHPStan level 6 clean, php-cs-fixer clean (without `PHP_CS_FIXER_IGNORE_ENV`), `composer validate` and `composer normalize --dry-run` clean.

No extension code is touched, so 7.0.0 behaviour is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUU6dfaQQ8TVWv8vcrLY8r