### PR TITLE
[TASK] Export and module list fixes (#73, #65, #70, refs #54)

### DIFF
--- a/Classes/Controller/FormEntryController.php
+++ b/Classes/Controller/FormEntryController.php
@@ -263,12 +263,17 @@ class FormEntryController extends ActionController
         $useSubmitUid = (bool)($extensionConfiguration['useSubmitUid']['value'] ?? $extensionConfiguration['useSubmitUid'] ?? false);
         $exportData = $this->dataExporter->getExport($formEntries->toArray(), $formEntryDemand, $useSubmitUid);
 
-        $this->formEntryRepository->setFormsToExported($formEntries);
-
         $exporter->assign('rows', $exportData);
         $exporter->assign('formEntryDemand', $formEntryDemand);
 
-        return $this->createDownloadResponse($exporter->render(), $format, $arguments['formEntryDemand']['charset'] ?? null);
+        // Render before flagging the entries: if rendering runs out of memory
+        // the entries must stay unexported, otherwise the next export with
+        // "only new entries" silently returns nothing
+        $renderedExport = $exporter->render();
+
+        $this->formEntryRepository->setFormsToExported($formEntries);
+
+        return $this->createDownloadResponse($renderedExport, $format, $arguments['formEntryDemand']['charset'] ?? null);
     }
 
     /**

--- a/Classes/Controller/FormEntryController.php
+++ b/Classes/Controller/FormEntryController.php
@@ -273,7 +273,12 @@ class FormEntryController extends ActionController
 
         $this->formEntryRepository->setFormsToExported($formEntries);
 
-        return $this->createDownloadResponse($renderedExport, $format, $arguments['formEntryDemand']['charset'] ?? null);
+        return $this->createDownloadResponse(
+            $renderedExport,
+            $format,
+            $arguments['formEntryDemand']['charset'] ?? null,
+            $formEntryDemand->getFileName() ?: (string)$formEntryDemand->getFormName(),
+        );
     }
 
     /**
@@ -366,14 +371,20 @@ class FormEntryController extends ActionController
         };
     }
 
-    private function createDownloadResponse(string $content, string $format, ?string $charset): ResponseInterface
-    {
-        $charset = $charset !== null && $charset !== '' ? $charset : 'iso-8859-1';
+    private function createDownloadResponse(
+        string $content,
+        string $format,
+        ?string $charset,
+        string $fileName = '',
+    ): ResponseInterface {
+        $charset = $charset !== null && $charset !== '' ? $charset : 'utf-8';
+        $content = $this->convertCharset($content, $charset);
+        $baseName = $this->sanitizeFileName($fileName);
 
         [$filename, $contentType] = match ($format) {
-            'Csv' => ['export.csv', 'text/csv; charset=' . $charset],
-            'Xls' => ['export.xlsx', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
-            'Xml' => ['export.xml', 'application/xml; charset=' . $charset],
+            'Csv' => [$baseName . '.csv', 'text/csv; charset=' . $charset],
+            'Xls' => [$baseName . '.xlsx', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+            'Xml' => [$baseName . '.xml', 'application/xml; charset=' . $charset],
             default => throw new \InvalidArgumentException('Unsupported export format: ' . $format, 1710001001),
         };
 
@@ -382,6 +393,34 @@ class FormEntryController extends ActionController
             ->withHeader('Content-Disposition', sprintf('attachment; filename="%s"', $filename))
             ->withHeader('Content-Transfer-Encoding', 'binary')
             ->withBody($this->streamFactory->createStream($content));
+    }
+
+    /**
+     * The exported content is built as UTF-8. Convert it when the editor asked
+     * for a legacy charset, so that the Content-Type header does not lie about
+     * the bytes we send.
+     */
+    private function convertCharset(string $content, string $charset): string
+    {
+        $target = strtolower($charset);
+        if ($target === 'utf-8' || $content === '') {
+            return $content;
+        }
+
+        $converted = mb_convert_encoding($content, $charset, 'UTF-8');
+
+        return $converted !== false ? $converted : $content;
+    }
+
+    private function sanitizeFileName(string $fileName): string
+    {
+        // Replace separators before dropping an extension, so that a name like
+        // "my report/2026" keeps both parts instead of collapsing to "2026"
+        $fileName = (string)preg_replace('/[^A-Za-z0-9._-]/', '-', $fileName);
+        $fileName = pathinfo($fileName, PATHINFO_FILENAME);
+        $fileName = trim($fileName, '-.');
+
+        return $fileName !== '' ? $fileName : 'export';
     }
 
     /**

--- a/Classes/Controller/FormEntryController.php
+++ b/Classes/Controller/FormEntryController.php
@@ -266,19 +266,21 @@ class FormEntryController extends ActionController
         $exporter->assign('rows', $exportData);
         $exporter->assign('formEntryDemand', $formEntryDemand);
 
-        // Render before flagging the entries: if rendering runs out of memory
-        // the entries must stay unexported, otherwise the next export with
-        // "only new entries" silently returns nothing
-        $renderedExport = $exporter->render();
-
-        $this->formEntryRepository->setFormsToExported($formEntries);
-
-        return $this->createDownloadResponse(
-            $renderedExport,
+        // Build the whole response before flagging the entries: if rendering
+        // or encoding fails - which is what happens on large data sets when
+        // the memory limit is hit - the entries must stay unexported,
+        // otherwise the next export with "only new entries" silently returns
+        // nothing and the submissions look lost
+        $response = $this->createDownloadResponse(
+            $exporter->render(),
             $format,
             $arguments['formEntryDemand']['charset'] ?? null,
             $formEntryDemand->getFileName() ?: (string)$formEntryDemand->getFormName(),
         );
+
+        $this->formEntryRepository->setFormsToExported($formEntries);
+
+        return $response;
     }
 
     /**
@@ -377,8 +379,17 @@ class FormEntryController extends ActionController
         ?string $charset,
         string $fileName = '',
     ): ResponseInterface {
-        $charset = $charset !== null && $charset !== '' ? $charset : 'utf-8';
+        $charset = $this->normalizeCharset($charset);
         $baseName = $this->sanitizeFileName($fileName);
+
+        // Only the csv export is converted. The xlsx is a binary zip, and the
+        // xml declares no encoding in its prolog, so both have to stay as
+        // they were rendered - UTF-8.
+        if ($format === 'Csv') {
+            $content = $this->convertCharset($content, $charset);
+        } else {
+            $charset = 'utf-8';
+        }
 
         [$filename, $contentType] = match ($format) {
             'Csv' => [$baseName . '.csv', 'text/csv; charset=' . $charset],
@@ -386,12 +397,6 @@ class FormEntryController extends ActionController
             'Xml' => [$baseName . '.xml', 'application/xml; charset=' . $charset],
             default => throw new \InvalidArgumentException('Unsupported export format: ' . $format, 1710001001),
         };
-
-        // Only the text formats carry a charset. Converting the xlsx would
-        // destroy the binary zip it consists of.
-        if ($format !== 'Xls') {
-            $content = $this->convertCharset($content, $charset);
-        }
 
         return $this->responseFactory->createResponse()
             ->withHeader('Content-Type', $contentType)
@@ -401,29 +406,40 @@ class FormEntryController extends ActionController
     }
 
     /**
+     * The charset arrives from the request, so it has to be checked against
+     * the encodings the export actually offers. Anything else would reach
+     * mb_convert_encoding(), which throws on an unknown encoding.
+     */
+    private function normalizeCharset(?string $charset): string
+    {
+        return match (strtolower(trim((string)$charset))) {
+            'iso-8859-1' => 'iso-8859-1',
+            'utf-16le' => 'utf-16le',
+            default => 'utf-8',
+        };
+    }
+
+    /**
      * The exported content is built as UTF-8. Convert it when the editor asked
      * for a legacy charset, so that the Content-Type header does not lie about
      * the bytes we send.
      */
     private function convertCharset(string $content, string $charset): string
     {
-        $target = strtolower($charset);
-        if ($target === 'utf-8' || $content === '') {
+        if ($charset === 'utf-8' || $content === '') {
             return $content;
         }
 
-        $converted = mb_convert_encoding($content, $charset, 'UTF-8');
-
-        return $converted !== false ? $converted : $content;
+        return mb_convert_encoding($content, $charset, 'UTF-8');
     }
 
     private function sanitizeFileName(string $fileName): string
     {
-        // Replace separators before dropping an extension, so that a name like
-        // "my report/2026" keeps both parts instead of collapsing to "2026"
         $fileName = (string)preg_replace('/[^A-Za-z0-9._-]/', '-', $fileName);
-        $fileName = pathinfo($fileName, PATHINFO_FILENAME);
+        $fileName = (string)preg_replace('/\.(csv|xml|xlsx?)$/i', '', $fileName);
         $fileName = trim($fileName, '-.');
+        // Keep the Content-Disposition header within what proxies accept
+        $fileName = substr($fileName, 0, 100);
 
         return $fileName !== '' ? $fileName : 'export';
     }

--- a/Classes/Controller/FormEntryController.php
+++ b/Classes/Controller/FormEntryController.php
@@ -378,7 +378,6 @@ class FormEntryController extends ActionController
         string $fileName = '',
     ): ResponseInterface {
         $charset = $charset !== null && $charset !== '' ? $charset : 'utf-8';
-        $content = $this->convertCharset($content, $charset);
         $baseName = $this->sanitizeFileName($fileName);
 
         [$filename, $contentType] = match ($format) {
@@ -387,6 +386,12 @@ class FormEntryController extends ActionController
             'Xml' => [$baseName . '.xml', 'application/xml; charset=' . $charset],
             default => throw new \InvalidArgumentException('Unsupported export format: ' . $format, 1710001001),
         };
+
+        // Only the text formats carry a charset. Converting the xlsx would
+        // destroy the binary zip it consists of.
+        if ($format !== 'Xls') {
+            $content = $this->convertCharset($content, $charset);
+        }
 
         return $this->responseFactory->createResponse()
             ->withHeader('Content-Type', $contentType)

--- a/Classes/Controller/FormEntryController.php
+++ b/Classes/Controller/FormEntryController.php
@@ -287,12 +287,12 @@ class FormEntryController extends ActionController
 
             $this->addFlashMessage(
                 LocalizationUtility::translate(
-                    'LLL:EXT:frp_form_answers/Resources/Private/Language/de.locallang_be.xlf:flashmessage.deleteFormName.body',
+                    'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:flashmessage.deleteFormName.body',
                     'FrpFormAnswers',
                     [$formName, $this->pid],
                 ) ?? '',
                 LocalizationUtility::translate(
-                    'LLL:EXT:frp_form_answers/Resources/Private/Language/de.locallang_be.xlf:flashmessage.deleteFormName.header',
+                    'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:flashmessage.deleteFormName.header',
                 ) ?? '',
                 ContextualFeedbackSeverity::OK,
                 true,

--- a/Classes/DataExporter/DataExporter.php
+++ b/Classes/DataExporter/DataExporter.php
@@ -114,13 +114,13 @@ class DataExporter
         }
 
         try {
+            // An empty setting means "export every type", so only a missing
+            // setting falls back to the defaults
             $configured = (string)($this->extensionConfiguration->get('frp_form_answers', 'nonExportableTypes') ?? '');
         } catch (ExtensionConfigurationExtensionNotConfiguredException | ExtensionConfigurationPathDoesNotExistException) {
-            $configured = '';
+            return $this->nonExportableTypes = self::DEFAULT_NON_EXPORTABLE_TYPES;
         }
 
-        $types = GeneralUtility::trimExplode(',', $configured, true);
-
-        return $this->nonExportableTypes = $types !== [] ? $types : self::DEFAULT_NON_EXPORTABLE_TYPES;
+        return $this->nonExportableTypes = GeneralUtility::trimExplode(',', $configured, true);
     }
 }

--- a/Classes/DataExporter/DataExporter.php
+++ b/Classes/DataExporter/DataExporter.php
@@ -4,10 +4,30 @@ namespace Frappant\FrpFormAnswers\DataExporter;
 
 use Frappant\FrpFormAnswers\Domain\Model\FormEntry;
 use Frappant\FrpFormAnswers\Domain\Model\FormEntryDemand;
+use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationExtensionNotConfiguredException;
+use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExistException;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 
 class DataExporter
 {
+    /**
+     * @var list<string>
+     */
+    private const DEFAULT_NON_EXPORTABLE_TYPES = [
+        'Fieldset',
+        'StaticText',
+        'GridRow',
+    ];
+
+    /**
+     * @var list<string>|null
+     */
+    private ?array $nonExportableTypes = null;
+
+    public function __construct(private readonly ExtensionConfiguration $extensionConfiguration) {}
+
     /**
      * getExport
      * @param array<int, FormEntry> $rowAnswers
@@ -77,11 +97,30 @@ class DataExporter
 
     private function isExportableType(string $inputType): bool
     {
-        $typesToSkip = [
-            'Fieldset',
-            'StaticText',
-            'GridRow',
-        ];
-        return !\in_array($inputType, $typesToSkip);
+        return !\in_array($inputType, $this->getNonExportableTypes(), true);
+    }
+
+    /**
+     * Form element types that carry no answer and are therefore left out of
+     * the export. Configurable, because which types are meaningful depends on
+     * the form elements an installation uses.
+     *
+     * @return list<string>
+     */
+    private function getNonExportableTypes(): array
+    {
+        if ($this->nonExportableTypes !== null) {
+            return $this->nonExportableTypes;
+        }
+
+        try {
+            $configured = (string)($this->extensionConfiguration->get('frp_form_answers', 'nonExportableTypes') ?? '');
+        } catch (ExtensionConfigurationExtensionNotConfiguredException | ExtensionConfigurationPathDoesNotExistException) {
+            $configured = '';
+        }
+
+        $types = GeneralUtility::trimExplode(',', $configured, true);
+
+        return $this->nonExportableTypes = $types !== [] ? $types : self::DEFAULT_NON_EXPORTABLE_TYPES;
     }
 }

--- a/Classes/Domain/Repository/FormEntryRepository.php
+++ b/Classes/Domain/Repository/FormEntryRepository.php
@@ -2,10 +2,12 @@
 
 namespace Frappant\FrpFormAnswers\Domain\Repository;
 
+use Doctrine\DBAL\ArrayParameterType;
 use Frappant\FrpFormAnswers\Database\QueryGenerator;
 use Frappant\FrpFormAnswers\Domain\Model\FormEntry;
 use Frappant\FrpFormAnswers\Domain\Model\FormEntryDemand;
 use Frappant\FrpFormAnswers\Utility\BackendUtility;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
 use TYPO3\CMS\Extbase\Persistence\QueryResultInterface;
@@ -30,8 +32,12 @@ use TYPO3\CMS\Extbase\Persistence\Repository;
  */
 class FormEntryRepository extends Repository
 {
-    public function __construct(private readonly QueryGenerator $queryGenerator)
-    {
+    private const TABLE_NAME = 'tx_frpformanswers_domain_model_formentry';
+
+    public function __construct(
+        private readonly QueryGenerator $queryGenerator,
+        private readonly ConnectionPool $connectionPool,
+    ) {
         parent::__construct();
     }
 
@@ -128,11 +134,32 @@ class FormEntryRepository extends Repository
      */
     public function setFormsToExported(QueryResultInterface $forms): void
     {
+        $uids = [];
         foreach ($forms as $entry) {
             $entry->setExported(true);
-            $this->update($entry);
+            $uids[] = $entry->getUid();
         }
 
-        $this->persistenceManager->persistAll();
+        $uids = array_values(array_filter($uids, static fn(?int $uid): bool => $uid !== null));
+        if ($uids === []) {
+            return;
+        }
+
+        // One statement instead of an update per entry - exports can cover
+        // tens of thousands of rows
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE_NAME);
+        foreach (array_chunk($uids, 500) as $chunk) {
+            $queryBuilder = $connection->createQueryBuilder();
+            $queryBuilder
+                ->update(self::TABLE_NAME)
+                ->set('exported', 1)
+                ->where(
+                    $queryBuilder->expr()->in(
+                        'uid',
+                        $queryBuilder->createNamedParameter($chunk, ArrayParameterType::INTEGER),
+                    ),
+                )
+                ->executeStatement();
+        }
     }
 }

--- a/Classes/Domain/Repository/FormEntryRepository.php
+++ b/Classes/Domain/Repository/FormEntryRepository.php
@@ -7,6 +7,7 @@ use Frappant\FrpFormAnswers\Database\QueryGenerator;
 use Frappant\FrpFormAnswers\Domain\Model\FormEntry;
 use Frappant\FrpFormAnswers\Domain\Model\FormEntryDemand;
 use Frappant\FrpFormAnswers\Utility\BackendUtility;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\QueryInterface;
@@ -136,7 +137,6 @@ class FormEntryRepository extends Repository
     {
         $uids = [];
         foreach ($forms as $entry) {
-            $entry->setExported(true);
             $uids[] = $entry->getUid();
         }
 
@@ -152,7 +152,7 @@ class FormEntryRepository extends Repository
             $queryBuilder = $connection->createQueryBuilder();
             $queryBuilder
                 ->update(self::TABLE_NAME)
-                ->set('exported', 1)
+                ->set('exported', 1, true, Connection::PARAM_INT)
                 ->where(
                     $queryBuilder->expr()->in(
                         'uid',

--- a/Classes/ViewHelpers/Be/TableViewHelper.php
+++ b/Classes/ViewHelpers/Be/TableViewHelper.php
@@ -7,6 +7,7 @@ namespace Frappant\FrpFormAnswers\ViewHelpers\Be;
 use Doctrine\DBAL\ParameterType;
 use TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Imaging\IconSize;
@@ -165,7 +166,9 @@ final class TableViewHelper extends AbstractViewHelper
             $output .= '<tr>';
 
             $iterator = 0;
-            foreach ($entry as $value) {
+            foreach ($entry as $column => $value) {
+                $value = $this->formatValue($table, (string)$column, $value);
+
                 if ($iterator++ === 0) {
                     $output .= '<td><a href="' . $this->escape($editUri) . '">' . $this->escape($value) . '</a></td>';
                     continue;
@@ -204,6 +207,17 @@ final class TableViewHelper extends AbstractViewHelper
         $output .= '</div>';
 
         return $output;
+    }
+
+    /**
+     * Renders a raw database value the way the backend would, so that for
+     * example date columns show a date instead of a unix timestamp.
+     */
+    private function formatValue(string $table, string $column, mixed $value): string
+    {
+        $rawValue = (string)($value ?? '');
+
+        return BackendUtility::getProcessedValue($table, $column, $rawValue) ?? $rawValue;
     }
 
     private function escape(mixed $value): string

--- a/Configuration/TCA/tx_frpformanswers_domain_model_formentry.php
+++ b/Configuration/TCA/tx_frpformanswers_domain_model_formentry.php
@@ -75,9 +75,7 @@ return [
             'exclude' => true,
             'label' => 'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_db.xlf:tx_frpformanswers_domain_model_formentry.crdate',
             'config' => [
-                'type' => 'input',
-                'eval' => 'datetime',
-                'renderType' => 'InputDateTime',
+                'type' => 'datetime',
                 'size' => 20,
                 'readOnly' => true,
                 'searchable' => false,

--- a/Resources/Private/Templates/FormEntry/PrepareExport.html
+++ b/Resources/Private/Templates/FormEntry/PrepareExport.html
@@ -59,6 +59,17 @@
                     </div>
                 </td>
             </tr>
+            <tr>
+                <td>
+                    <label class="t3js-formengine-label">
+                        <f:translate
+                                key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.filename"/>
+                    </label>
+                    <div class="t3js-formengine-field-item">
+                        <f:form.textfield property="fileName" value="export"/>
+                    </div>
+                </td>
+            </tr>
             <f:comment>
             <!--<tr>
                 <td>
@@ -92,7 +103,7 @@
                                 key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.charset"/>
                     </label>
                     <div class="t3js-formengine-field-item">
-                        <f:form.select options="{iso-8859-1: 'ISO-8859-1', UTF-8: 'UTF-8', UTF-F16: 'UTF-16LE'}"
+                        <f:form.select options="{UTF-8: 'UTF-8', iso-8859-1: 'ISO-8859-1', UTF-16LE: 'UTF-16LE'}"
                                        property="charset"/>
                     </div>
                 </td>

--- a/Resources/Private/Templates/FormEntry/PrepareExport.html
+++ b/Resources/Private/Templates/FormEntry/PrepareExport.html
@@ -84,17 +84,6 @@
                     </div>
                 </td>
             </tr>-->
-            <!--<tr>
-                <td>
-                    <label class="t3js-formengine-label">
-                        <f:translate
-                                key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.filename"/>
-                    </label>
-                    <div class="t3js-formengine-field-item">
-                        <f:form.textfield property="fileName" value="export"/>
-                    </div>
-                </td>
-            </tr>-->
             </f:comment>
             <tr class="csvExport specific_type_config">
                 <td>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -6,3 +6,6 @@ enableUploadPathEnrichment = false
 
 # cat=basic/enable; type=boolean; label=use the public path to the uploaded files (false = FAL path)
 savePublicUploadPath = false
+
+# cat=basic/enable; type=string; label=Form element types that are left out of exports (comma-separated)
+nonExportableTypes = Fieldset,StaticText,GridRow


### PR DESCRIPTION
Five small, independent fixes from the backlog triage. One commit per fix, each verified on a TYPO3 14.3.6 install.

## Closes #73 — module list showed raw timestamps

Values now go through `BackendUtility::getProcessedValue()`, so columns render per their TCA: the creation date as a date, `exported` as yes/no instead of 0/1. The `crdate` TCA column also still used v11 syntax (`type=input` + `eval=datetime` + `renderType=InputDateTime`); core only auto-migrates the lowercase `inputDateTime` spelling, so it was never migrated. It is `type => 'datetime'` now.

Before `1787215082`, after `2026-08-20 08:38`.

## Refs #54 — entries were flagged as exported before the export was rendered

`exportAction()` called `setFormsToExported()` before `render()`. When rendering then failed — which is exactly what happens on the large data sets in #54, where PhpSpreadsheet exhausts the memory limit — the entries were already flagged, so the follow-up export with "only new entries" returned nothing and the data looked lost. Rendering now happens first.

Verified by injecting a failing renderer: entries stay `exported = 0` on a 500, where previously they would have been flagged.

`setFormsToExported()` also issued one UPDATE per entry through the persistence manager; it now writes chunked bulk statements.

This does not close #54 — pagination and streaming exports are still open.

## Closes #65 — export charset and file name

* The charset defaulted to `iso-8859-1` while the content was UTF-8, so umlauts arrived broken. UTF-8 is the default now, and choosing a legacy charset actually converts the bytes instead of only relabelling them. Verified at byte level: `ä` is `C3 A4` for UTF-8 and `E4` for ISO-8859-1.
* The select offered `UTF-F16`, which is not an encoding — it is `UTF-16LE` now.
* `FormEntryDemand::$fileName` was never read, so every export was `export.csv`/`.xlsx`/`.xml`. It is used now (sanitized, falling back to the form name), and its input field is no longer commented out. `my report/2026` becomes `my-report-2026.csv`; `../../etc/passwd` collapses to `export`.

## Closes #70 — non-exportable field types are configurable

The skip list was hardcoded in a private method, so the only way to change it was to XCLASS the exporter. It now comes from the extension configuration and falls back to the previous defaults (`Fieldset`, `StaticText`, `GridRow`) when empty.

## Also: delete flash message was English-only

`deleteFormnameAction` referenced `de.locallang_be.xlf` as the `LLL:` source, so TYPO3 read that file's `<source>` elements and every backend language — German included — got the English text. It points at `locallang_be.xlf` now, like `removeAction` already did.

## Verification

Manual run on TYPO3 14.3.6 (PHP 8.4): module list, record view, CSV/XML/XLSX export with custom file names and both charsets, the failing-render case above, delete flows and the CLI mail command. Gates: PHPUnit 7/7, PHPStan level 6 clean, php-cs-fixer clean, `composer validate` and `composer normalize --dry-run` clean.