### PR TITLE
[TASK] Large data sets and backend styling (refs #54)

### DIFF
--- a/Classes/Controller/FormEntryController.php
+++ b/Classes/Controller/FormEntryController.php
@@ -247,8 +247,7 @@ class FormEntryController extends ActionController
             return $this->redirect('list', null, null, ['id' => $this->pid]);
         }
 
-        $formEntries = $this->formEntryRepository->findbyDemand($formEntryDemand, $this->pid);
-        if (count($formEntries) === 0) {
+        if ($this->formEntryRepository->countByDemand($formEntryDemand, $this->pid) === 0) {
             $this->addFlashMessage(
                 'No entries found with your criteria',
                 'No Entries found',
@@ -261,7 +260,22 @@ class FormEntryController extends ActionController
 
         $extensionConfiguration = $this->getExtensionConfiguration();
         $useSubmitUid = (bool)($extensionConfiguration['useSubmitUid']['value'] ?? $extensionConfiguration['useSubmitUid'] ?? false);
-        $exportData = $this->dataExporter->getExport($formEntries->toArray(), $formEntryDemand, $useSubmitUid);
+
+        // Stream the entries through the exporter and remember which ones were
+        // written, instead of holding every hydrated entry in memory
+        $exportedUids = [];
+        $entries = (function () use ($formEntryDemand, &$exportedUids): \Generator {
+            foreach ($this->formEntryRepository->iterateByDemand($formEntryDemand, $this->pid) as $entry) {
+                $uid = $entry->getUid();
+                if ($uid !== null) {
+                    $exportedUids[] = $uid;
+                }
+
+                yield $entry;
+            }
+        })();
+
+        $exportData = $this->dataExporter->getExport($entries, $formEntryDemand, $useSubmitUid);
 
         $exporter->assign('rows', $exportData);
         $exporter->assign('formEntryDemand', $formEntryDemand);
@@ -278,7 +292,7 @@ class FormEntryController extends ActionController
             $formEntryDemand->getFileName() ?: (string)$formEntryDemand->getFormName(),
         );
 
-        $this->formEntryRepository->setFormsToExported($formEntries);
+        $this->formEntryRepository->setExportedByUids($exportedUids);
 
         return $response;
     }

--- a/Classes/DataExporter/DataExporter.php
+++ b/Classes/DataExporter/DataExporter.php
@@ -30,31 +30,36 @@ class DataExporter
 
     /**
      * getExport
-     * @param array<int, FormEntry> $rowAnswers
+     *
+     * Accepts any iterable, so that the caller can feed the entries in
+     * chunks instead of loading tens of thousands of them at once.
+     *
+     * @param iterable<FormEntry> $rowAnswers
      * @return array<int, array<string, mixed>>
      */
-    public function getExport(array $rowAnswers, FormEntryDemand $formEntryDemand, bool $useSubmitUid): array
+    public function getExport(iterable $rowAnswers, FormEntryDemand $formEntryDemand, bool $useSubmitUid): array
     {
-        if ($rowAnswers === []) {
-            return [];
-        }
-
         $rows = [];
         $header = [];
-        $headerKeys = array_values($rowAnswers[0]->getAnswers());
+        $headerWritten = false;
 
-        // add header for crdate
-        $headerKeys[] = [
-            'value' => '',
-            'conf' => [
-                'label' => LocalizationUtility::translate('LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_db.xlf:tx_frpformanswers_domain_model_formentry.crdate'),
-                'inputType' => 'DateTime',
-            ],
-        ];
+        foreach ($rowAnswers as $entry) {
+            if (!$headerWritten) {
+                $headerKeys = array_values($entry->getAnswers());
 
-        $this->setHeaders($formEntryDemand, $headerKeys, $header);
+                // add header for crdate
+                $headerKeys[] = [
+                    'value' => '',
+                    'conf' => [
+                        'label' => LocalizationUtility::translate('LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_db.xlf:tx_frpformanswers_domain_model_formentry.crdate'),
+                        'inputType' => 'DateTime',
+                    ],
+                ];
 
-        foreach ($rowAnswers as $key => $entry) {
+                $this->setHeaders($formEntryDemand, $headerKeys, $header);
+                $headerWritten = true;
+            }
+
             $uid = ($useSubmitUid) ? $entry->getSubmitUid() : $entry->getUid();
 
             if ($formEntryDemand->getUidLabel()) {
@@ -67,6 +72,10 @@ class DataExporter
             }
             // The model stores crdate as unix timestamp; exporters format \DateTime values
             $rows[$uid]['crdate'] = (new \DateTime())->setTimestamp($entry->getCrdate());
+        }
+
+        if ($rows === []) {
+            return [];
         }
 
         array_unshift($rows, $header);

--- a/Classes/Domain/Repository/FormEntryRepository.php
+++ b/Classes/Domain/Repository/FormEntryRepository.php
@@ -86,29 +86,11 @@ class FormEntryRepository extends Repository
             $query->matching($query->logicalAnd(...$constraints));
         }
 
+        // A stable order is required: the export reads the result in chunks,
+        // and without it the database may return a row twice or not at all
+        $query->setOrderings(['uid' => QueryInterface::ORDER_ASCENDING]);
+
         return $query;
-    }
-
-    /**
-     * Find all within a Page and all subpages
-     *
-     * @param int $pid start page identifier
-     * @return QueryResultInterface<int, FormEntry>
-     */
-    public function findAllInPidAndRootline(int $pid): QueryResultInterface
-    {
-        $query = $this->createQuery();
-        $query->getQuerySettings()->setRespectStoragePage(false);
-
-        $pids = $this->findAccessiblePidsInRootline($pid);
-
-        if (count($pids)) {
-            $query->matching($query->in('pid', $pids));
-        }
-
-        $query->setOrderings(['pid' => QueryInterface::ORDER_ASCENDING]);
-
-        return $query->execute();
     }
 
     /**
@@ -261,19 +243,6 @@ class FormEntryRepository extends Repository
 
         $first = $query->execute()->getFirst();
         return $first instanceof FormEntry ? $first : null;
-    }
-
-    /**
-     * @param QueryResultInterface<int, FormEntry> $forms
-     */
-    public function setFormsToExported(QueryResultInterface $forms): void
-    {
-        $uids = [];
-        foreach ($forms as $entry) {
-            $uids[] = $entry->getUid();
-        }
-
-        $this->setExportedByUids($uids);
     }
 
     /**

--- a/Classes/Domain/Repository/FormEntryRepository.php
+++ b/Classes/Domain/Repository/FormEntryRepository.php
@@ -49,7 +49,14 @@ class FormEntryRepository extends Repository
      */
     public function findByDemand(FormEntryDemand $formEntryDemand, int $pid = 0): QueryResultInterface
     {
+        return $this->buildDemandQuery($formEntryDemand, $pid)->execute();
+    }
 
+    /**
+     * @return QueryInterface<FormEntry>
+     */
+    private function buildDemandQuery(FormEntryDemand $formEntryDemand, int $pid): QueryInterface
+    {
         $query = $this->createQuery();
 
         if ($formEntryDemand->getAllPids()) {
@@ -78,7 +85,8 @@ class FormEntryRepository extends Repository
         if (count($constraints)) {
             $query->matching($query->logicalAnd(...$constraints));
         }
-        return $query->execute();
+
+        return $query;
     }
 
     /**
@@ -92,11 +100,7 @@ class FormEntryRepository extends Repository
         $query = $this->createQuery();
         $query->getQuerySettings()->setRespectStoragePage(false);
 
-        $pids = GeneralUtility::trimExplode(',', $this->queryGenerator->getTreeList($pid, 20, 0, '1'), true);
-
-        if (!BackendUtility::isBackendAdmin()) {
-            $pids = BackendUtility::filterPagesForAccess($pids);
-        }
+        $pids = $this->findAccessiblePidsInRootline($pid);
 
         if (count($pids)) {
             $query->matching($query->in('pid', $pids));
@@ -105,6 +109,135 @@ class FormEntryRepository extends Repository
         $query->setOrderings(['pid' => QueryInterface::ORDER_ASCENDING]);
 
         return $query->execute();
+    }
+
+    /**
+     * Yields the entries of a demand in chunks, so that an export does not
+     * hold tens of thousands of hydrated objects at once. The persistence
+     * session is cleared per chunk, otherwise the objects would pile up in
+     * the identity map anyway.
+     *
+     * @return \Generator<int, FormEntry>
+     */
+    public function iterateByDemand(FormEntryDemand $formEntryDemand, int $pid = 0, int $chunkSize = 500): \Generator
+    {
+        $offset = 0;
+
+        do {
+            $query = $this->buildDemandQuery($formEntryDemand, $pid);
+            $query->setOffset($offset);
+            $query->setLimit($chunkSize);
+
+            $entries = $query->execute()->toArray();
+
+            foreach ($entries as $entry) {
+                yield $entry;
+            }
+
+            $offset += $chunkSize;
+            $fetched = count($entries);
+
+            $this->persistenceManager->clearState();
+        } while ($fetched === $chunkSize);
+    }
+
+    /**
+     * Counts the entries of a demand without loading them.
+     */
+    public function countByDemand(FormEntryDemand $formEntryDemand, int $pid = 0): int
+    {
+        return $this->buildDemandQuery($formEntryDemand, $pid)->execute()->count();
+    }
+
+    /**
+     * The pages below (and including) the given one that the current backend
+     * user is allowed to see.
+     *
+     * @return list<int>
+     */
+    public function findAccessiblePidsInRootline(int $pid): array
+    {
+        $pids = GeneralUtility::trimExplode(',', $this->queryGenerator->getTreeList($pid, 20, 0, '1'), true);
+
+        if (!BackendUtility::isBackendAdmin()) {
+            $pids = BackendUtility::filterPagesForAccess($pids);
+        }
+
+        return array_values(array_map('intval', $pids));
+    }
+
+    /**
+     * Counts the entries per page and form name, without loading them.
+     *
+     * @param list<int> $pids
+     * @return array<int, array<string, array{tot: int, new: int}>>
+     */
+    public function countByPidAndForm(array $pids): array
+    {
+        if ($pids === []) {
+            return [];
+        }
+
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_NAME);
+        $rows = $queryBuilder
+            ->select('pid', 'form')
+            ->addSelectLiteral(
+                'COUNT(*) AS ' . $queryBuilder->quoteIdentifier('tot'),
+                'SUM(' . $queryBuilder->quoteIdentifier('exported') . ') AS ' . $queryBuilder->quoteIdentifier('exported_count'),
+            )
+            ->from(self::TABLE_NAME)
+            ->where(
+                $queryBuilder->expr()->in(
+                    'pid',
+                    $queryBuilder->createNamedParameter($pids, ArrayParameterType::INTEGER),
+                ),
+            )
+            ->groupBy('pid', 'form')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $counts = [];
+        foreach ($rows as $row) {
+            $formName = (string)$row['form'];
+            if ($formName === '') {
+                continue;
+            }
+
+            $total = (int)$row['tot'];
+            $counts[(int)$row['pid']][$formName] = [
+                'tot' => $total,
+                'new' => $total - (int)$row['exported_count'],
+            ];
+        }
+
+        return $counts;
+    }
+
+    /**
+     * Returns the distinct values of a column for one page, without loading
+     * the entries themselves.
+     *
+     * @return list<string>
+     */
+    public function findDistinctValues(string $column, int $pid): array
+    {
+        if (!in_array($column, ['form', 'field_hash'], true)) {
+            throw new \InvalidArgumentException('Unsupported column: ' . $column, 1755690000);
+        }
+
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_NAME);
+        $values = $queryBuilder
+            ->select($column)
+            ->from(self::TABLE_NAME)
+            ->where(
+                $queryBuilder->expr()->eq('pid', $queryBuilder->createNamedParameter($pid, Connection::PARAM_INT)),
+            )
+            ->groupBy($column)
+            ->orderBy($column)
+            ->executeQuery()
+            ->fetchFirstColumn();
+
+        return array_values(array_filter(array_map('strval', $values), static fn(string $value): bool => $value !== ''));
     }
 
     /**
@@ -140,7 +273,15 @@ class FormEntryRepository extends Repository
             $uids[] = $entry->getUid();
         }
 
-        $uids = array_values(array_filter($uids, static fn(?int $uid): bool => $uid !== null));
+        $this->setExportedByUids($uids);
+    }
+
+    /**
+     * @param array<int, int|null> $uids
+     */
+    public function setExportedByUids(array $uids): void
+    {
+        $uids = array_values(array_unique(array_filter($uids, static fn(?int $uid): bool => $uid !== null)));
         if ($uids === []) {
             return;
         }

--- a/Classes/Utility/FormAnswersUtility.php
+++ b/Classes/Utility/FormAnswersUtility.php
@@ -40,10 +40,7 @@ final class FormAnswersUtility
      */
     public function getAllFormNames(int $pid): array
     {
-        return $this->getUniqueFormValues(
-            $pid,
-            static fn(object $answer): ?string => $answer->getForm(),
-        );
+        return $this->formEntryRepository->findDistinctValues('form', $pid);
     }
 
     /**
@@ -53,10 +50,7 @@ final class FormAnswersUtility
      */
     public function getAllFormHashes(int $pid): array
     {
-        return $this->getUniqueFormValues(
-            $pid,
-            static fn(object $answer): ?string => $answer->getFieldHash(),
-        );
+        return $this->formEntryRepository->findDistinctValues('field_hash', $pid);
     }
 
     private function getCurrentPageId(?ServerRequestInterface $request): int
@@ -90,55 +84,19 @@ final class FormAnswersUtility
      */
     private function addFormEntryCountsForPage(array &$pageIds, int $pageId): void
     {
-        foreach ($this->formEntryRepository->findAllInPidAndRootline($pageId) as $formEntry) {
-            $pid = $formEntry->getPid();
-            $formName = $formEntry->getForm();
+        // Counting happens in the database. Loading the entries as objects
+        // exhausts the memory limit on pages with tens of thousands of them.
+        $accessiblePids = $this->formEntryRepository->findAccessiblePidsInRootline($pageId);
 
-            if (!is_int($pid) || $formName === null || $formName === '') {
-                continue;
-            }
+        foreach ($this->formEntryRepository->countByPidAndForm($accessiblePids) as $pid => $formCounts) {
+            foreach ($formCounts as $formName => $counts) {
+                $pageIds[$pid][$formName]['tot'] = ($pageIds[$pid][$formName]['tot'] ?? 0) + $counts['tot'];
 
-            $pageIds[$pid][$formName]['tot'] = ($pageIds[$pid][$formName]['tot'] ?? 0) + 1;
-
-            if (!$formEntry->isExported()) {
-                $pageIds[$pid][$formName]['new'] = ($pageIds[$pid][$formName]['new'] ?? 0) + 1;
+                if ($counts['new'] > 0) {
+                    $pageIds[$pid][$formName]['new'] = ($pageIds[$pid][$formName]['new'] ?? 0) + $counts['new'];
+                }
             }
         }
-    }
-
-    /**
-     * @param callable(object): ?string $valueGetter
-     * @return list<string>
-     */
-    private function getUniqueFormValues(int $pid, callable $valueGetter): array
-    {
-        $values = [];
-
-        foreach ($this->findAllByStoragePid($pid) as $answer) {
-            $value = $valueGetter($answer);
-
-            if ($value === null || $value === '') {
-                continue;
-            }
-
-            $values[$value] = true;
-        }
-
-        return array_keys($values);
-    }
-
-    /**
-     * @return iterable<\Frappant\FrpFormAnswers\Domain\Model\FormEntry>
-     */
-    private function findAllByStoragePid(int $pid): iterable
-    {
-        $query = $this->formEntryRepository->createQuery();
-
-        $query->getQuerySettings()
-            ->setRespectStoragePage(true)
-            ->setStoragePageIds([$pid]);
-
-        return $query->execute();
     }
 
     private function getRequest(): ?ServerRequestInterface

--- a/Classes/View/FormEntry/ExportCsv.php
+++ b/Classes/View/FormEntry/ExportCsv.php
@@ -39,7 +39,7 @@ class ExportCsv
     protected $delimiter = [
         'komma' => ',',
         'semikolon' => ';',
-        'tab' => '\t',
+        'tab' => "\t",
     ];
 
     /**

--- a/Classes/View/FormEntry/ExportCsv.php
+++ b/Classes/View/FormEntry/ExportCsv.php
@@ -97,13 +97,15 @@ class ExportCsv
      */
     public function render(): string
     {
+        $demand = $this->variables['formEntryDemand'];
+        // The quick export on the overview submits no csv options, so fall
+        // back to the defaults instead of passing null into fputcsv2()
+        $delimiter = $this->delimiter[$demand->getDelimiter()] ?? ';';
+        $enclosure = $this->enclosure[$demand->getEnclosure()] ?? '"';
+
         ob_start();
         foreach ($this->variables['rows'] as $fields) {
-            echo $this->fputcsv2(
-                $fields,
-                $this->delimiter[$this->variables['formEntryDemand']->getDelimiter()],
-                $this->enclosure[$this->variables['formEntryDemand']->getEnclosure()]
-            );
+            echo $this->fputcsv2($fields, $delimiter, $enclosure);
         }
         return ob_get_clean();
     }

--- a/Classes/View/FormEntry/ExportXls.php
+++ b/Classes/View/FormEntry/ExportXls.php
@@ -4,12 +4,8 @@ namespace Frappant\FrpFormAnswers\View\FormEntry;
 
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Cell\StringValueBinder;
-use PhpOffice\PhpSpreadsheet\Settings;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
-use Symfony\Component\Cache\Psr16Cache;
-use TYPO3\CMS\Core\Core\Environment;
 
 /***************************************************************
  *
@@ -95,15 +91,6 @@ class ExportXls
                 ->setLastModifiedBy('Frappant Forms Export')
                 ->setCreated(time());
         }
-
-        // Keep the cells on disk instead of in memory. Without this an export
-        // of a few ten thousand entries exhausts the memory limit, because
-        // PhpSpreadsheet holds every single cell as an object.
-        Settings::setCache(new Psr16Cache(new FilesystemAdapter(
-            'frp_form_answers_export',
-            0,
-            Environment::getVarPath() . '/cache/data/frp_form_answers',
-        )));
 
         $rows = $this->variables['rows'];
         // PHPExcel does not work with associative arrays - then to indexed array

--- a/Classes/View/FormEntry/ExportXls.php
+++ b/Classes/View/FormEntry/ExportXls.php
@@ -4,8 +4,12 @@ namespace Frappant\FrpFormAnswers\View\FormEntry;
 
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\Cell\StringValueBinder;
+use PhpOffice\PhpSpreadsheet\Settings;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Psr16Cache;
+use TYPO3\CMS\Core\Core\Environment;
 
 /***************************************************************
  *
@@ -91,6 +95,15 @@ class ExportXls
                 ->setLastModifiedBy('Frappant Forms Export')
                 ->setCreated(time());
         }
+
+        // Keep the cells on disk instead of in memory. Without this an export
+        // of a few ten thousand entries exhausts the memory limit, because
+        // PhpSpreadsheet holds every single cell as an object.
+        Settings::setCache(new Psr16Cache(new FilesystemAdapter(
+            'frp_form_answers_export',
+            0,
+            Environment::getVarPath() . '/cache/data/frp_form_answers',
+        )));
 
         $rows = $this->variables['rows'];
         // PHPExcel does not work with associative arrays - then to indexed array

--- a/Classes/ViewHelpers/Be/TableViewHelper.php
+++ b/Classes/ViewHelpers/Be/TableViewHelper.php
@@ -13,6 +13,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Imaging\IconSize;
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
 final class TableViewHelper extends AbstractViewHelper
@@ -166,7 +167,7 @@ final class TableViewHelper extends AbstractViewHelper
         $output = '<div class="recordlist mb-5 mt-4 border">';
         $output .= '<div class="recordlist-heading row m-0 p-2 g-0 gap-1 align-items-center multi-record-selection-panel">
             <div class="col ms-2">
-                <div class="recordlist-heading-title">Entry (' . $numberOfEntries . ')</div>
+                <div class="recordlist-heading-title">' . $this->escape($this->translate('table.entries', [$numberOfEntries])) . '</div>
             </div>
         </div>';
 
@@ -177,7 +178,7 @@ final class TableViewHelper extends AbstractViewHelper
         foreach (array_keys($entries[0]) as $key) {
             $output .= '<th>' . $this->escape($key) . '</th>';
         }
-        $output .= '<th>Actions</th>';
+        $output .= '<th>' . $this->escape($this->translate('table.actions')) . '</th>';
         $output .= '</tr></thead>';
 
         $output .= '<tbody>';
@@ -311,11 +312,11 @@ final class TableViewHelper extends AbstractViewHelper
         $output = '<div class="recordlist mb-5 mt-4 border">';
         $output .= '<div class="recordlist-heading row m-0 p-2 g-0 gap-1 align-items-center multi-record-selection-panel">
             <div class="col ms-2">
-                <div class="recordlist-heading-title">Entry (0)</div>
+                <div class="recordlist-heading-title">' . $this->escape($this->translate('table.entries', [0])) . '</div>
             </div>
         </div>';
         $output .= '<div class="recordlist-body">';
-        $output .= '<div class="alert alert-info">Keine Einträge vorhanden</div>';
+        $output .= '<div class="alert alert-info">' . $this->escape($this->translate('table.noentries')) . '</div>';
         $output .= '</div>';
         $output .= '</div>';
 
@@ -331,6 +332,18 @@ final class TableViewHelper extends AbstractViewHelper
         $rawValue = (string)($value ?? '');
 
         return BackendUtility::getProcessedValue($table, $column, $rawValue) ?? $rawValue;
+    }
+
+    /**
+     * @param array<int, mixed> $arguments
+     */
+    private function translate(string $key, array $arguments = []): string
+    {
+        return LocalizationUtility::translate(
+            'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:' . $key,
+            null,
+            $arguments,
+        ) ?? $key;
     }
 
     private function escape(mixed $value): string

--- a/Classes/ViewHelpers/Be/TableViewHelper.php
+++ b/Classes/ViewHelpers/Be/TableViewHelper.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace Frappant\FrpFormAnswers\ViewHelpers\Be;
 
 use Doctrine\DBAL\ParameterType;
+use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Imaging\IconSize;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -18,6 +20,8 @@ final class TableViewHelper extends AbstractViewHelper
     protected $escapeOutput = false;
 
     private const MODULE_ROUTE = 'web_FrpFormAnswersFormanswers';
+
+    private const DEFAULT_ITEMS_PER_PAGE = 50;
 
     public function __construct(
         private readonly UriBuilder $uriBuilder,
@@ -33,6 +37,8 @@ final class TableViewHelper extends AbstractViewHelper
         $this->registerArgument('filter', 'array', 'Filter conditions', false, []);
         $this->registerArgument('columns', 'array', 'Columns to display', true);
         $this->registerArgument('pid', 'int', 'PID', true);
+        $this->registerArgument('itemsPerPage', 'int', 'Number of entries per page', false, self::DEFAULT_ITEMS_PER_PAGE);
+        $this->registerArgument('page', 'int', 'Page to display, 1 based', false, 1);
     }
 
     /**
@@ -75,7 +81,16 @@ final class TableViewHelper extends AbstractViewHelper
             $queryBuilder->andWhere(...$filter);
         }
 
+        $itemsPerPage = max(1, (int)$this->arguments['itemsPerPage']);
+        $numberOfEntries = $this->countEntries($queryBuilder);
+        $numberOfPages = max(1, (int)ceil($numberOfEntries / $itemsPerPage));
+        $currentPage = min(max(1, $this->currentPage($table)), $numberOfPages);
+
+        // Never render the whole table: a page can hold tens of thousands of
+        // entries, and every row costs three backend uris
         $entries = $queryBuilder
+            ->setFirstResult(($currentPage - 1) * $itemsPerPage)
+            ->setMaxResults($itemsPerPage)
             ->executeQuery()
             ->fetchAllAssociative();
 
@@ -97,7 +112,40 @@ final class TableViewHelper extends AbstractViewHelper
             $pid,
             $pencilIcon,
             $trashIcon,
+            $numberOfEntries,
+            $currentPage,
+            $numberOfPages,
         );
+    }
+
+    /**
+     * The page to show: taken from the request, so that the pagination links
+     * work without the template having to pass anything through.
+     */
+    private function currentPage(string $table): int
+    {
+        $page = (int)$this->arguments['page'];
+        $request = $GLOBALS['TYPO3_REQUEST'] ?? null;
+
+        if ($request instanceof ServerRequestInterface) {
+            $page = (int)($request->getQueryParams()[$this->pageParameterName($table)] ?? $page);
+        }
+
+        return $page;
+    }
+
+    /**
+     * Counts the rows the given query would return, without fetching them.
+     */
+    private function countEntries(QueryBuilder $queryBuilder): int
+    {
+        $countQuery = clone $queryBuilder;
+        $countQuery->resetOrderBy();
+
+        return (int)$countQuery
+            ->count('uid')
+            ->executeQuery()
+            ->fetchOne();
     }
 
     /**
@@ -111,9 +159,10 @@ final class TableViewHelper extends AbstractViewHelper
         int $pid,
         string $pencilIcon,
         string $trashIcon,
+        int $numberOfEntries,
+        int $currentPage,
+        int $numberOfPages,
     ): string {
-        $numberOfEntries = count($entries);
-
         $output = '<div class="recordlist mb-5 mt-4 border">';
         $output .= '<div class="recordlist-heading row m-0 p-2 g-0 gap-1 align-items-center multi-record-selection-panel">
             <div class="col ms-2">
@@ -133,15 +182,17 @@ final class TableViewHelper extends AbstractViewHelper
 
         $output .= '<tbody>';
 
+        // Loop invariant: building it per row means one more route lookup and
+        // hmac per entry
+        $backUrl = (string)$this->uriBuilder->buildUriFromRoute(
+            self::MODULE_ROUTE,
+            [
+                'id' => $pid,
+            ],
+        );
+
         foreach ($entries as $entry) {
             $uid = (int)$entry['uid'];
-
-            $backUrl = (string)$this->uriBuilder->buildUriFromRoute(
-                self::MODULE_ROUTE,
-                [
-                    'id' => $pid,
-                ],
-            );
 
             $editUri = (string)$this->uriBuilder->buildUriFromRoutePath(
                 '/record/edit',
@@ -187,10 +238,72 @@ final class TableViewHelper extends AbstractViewHelper
 
         $output .= '</tbody>';
         $output .= '</table>';
+        $output .= $this->renderPagination($table, $pid, $currentPage, $numberOfPages);
         $output .= '</div>';
         $output .= '</div>';
 
         return $output;
+    }
+
+    /**
+     * @throws RouteNotFoundException
+     */
+    private function renderPagination(string $table, int $pid, int $currentPage, int $numberOfPages): string
+    {
+        if ($numberOfPages < 2) {
+            return '';
+        }
+
+        $pageParameter = $this->pageParameterName($table);
+        $item = function (int $page, string $label, bool $disabled = false, bool $active = false) use ($pid, $pageParameter): string {
+            $uri = (string)$this->uriBuilder->buildUriFromRoute(
+                self::MODULE_ROUTE,
+                [
+                    'id' => $pid,
+                    $pageParameter => $page,
+                ],
+            );
+
+            $classes = 'page-item' . ($disabled ? ' disabled' : '') . ($active ? ' active' : '');
+
+            return '<li class="' . $classes . '"><a class="page-link" href="' . $this->escape($uri) . '">' . $this->escape($label) . '</a></li>';
+        };
+
+        $output = '<nav class="p-2"><ul class="pagination pagination-sm mb-0">';
+        $output .= $item(max(1, $currentPage - 1), '‹', $currentPage <= 1);
+
+        foreach ($this->pageNumbers($currentPage, $numberOfPages) as $page) {
+            $output .= $item($page, (string)$page, false, $page === $currentPage);
+        }
+
+        $output .= $item(min($numberOfPages, $currentPage + 1), '›', $currentPage >= $numberOfPages);
+        $output .= '</ul></nav>';
+
+        return $output;
+    }
+
+    /**
+     * A window around the current page, so that thousands of pages do not
+     * produce thousands of links.
+     *
+     * @return list<int>
+     */
+    private function pageNumbers(int $currentPage, int $numberOfPages): array
+    {
+        $first = max(1, $currentPage - 2);
+        $last = min($numberOfPages, $first + 4);
+        $first = max(1, $last - 4);
+
+        return range($first, $last);
+    }
+
+    /**
+     * Each table on the page needs its own page parameter, otherwise paging
+     * one form's entries would page all of them.
+     */
+    private function pageParameterName(string $table): string
+    {
+        return 'entryPage_' . substr(md5($table . '-' . ($this->arguments['filter'][0] ?? '')), 0, 8);
     }
 
     private function renderEmptyTable(): string

--- a/Classes/ViewHelpers/Be/TableViewHelper.php
+++ b/Classes/ViewHelpers/Be/TableViewHelper.php
@@ -35,7 +35,7 @@ final class TableViewHelper extends AbstractViewHelper
         parent::initializeArguments();
 
         $this->registerArgument('table', 'string', 'Database table name', true);
-        $this->registerArgument('filter', 'array', 'Filter conditions', false, []);
+        $this->registerArgument('formName', 'string', 'Restrict to entries of this form', false, '');
         $this->registerArgument('columns', 'array', 'Columns to display', true);
         $this->registerArgument('pid', 'int', 'PID', true);
         $this->registerArgument('itemsPerPage', 'int', 'Number of entries per page', false, self::DEFAULT_ITEMS_PER_PAGE);
@@ -48,7 +48,7 @@ final class TableViewHelper extends AbstractViewHelper
     public function render(): string
     {
         $table = (string)$this->arguments['table'];
-        $filter = (array)$this->arguments['filter'];
+        $formName = (string)$this->arguments['formName'];
         $columns = (array)$this->arguments['columns'];
         $pid = (int)$this->arguments['pid'];
 
@@ -78,8 +78,13 @@ final class TableViewHelper extends AbstractViewHelper
             $queryBuilder->addSelect($column);
         }
 
-        if ($filter !== []) {
-            $queryBuilder->andWhere(...$filter);
+        if ($formName !== '') {
+            $queryBuilder->andWhere(
+                $queryBuilder->expr()->eq(
+                    'form',
+                    $queryBuilder->createNamedParameter($formName),
+                ),
+            );
         }
 
         $itemsPerPage = max(1, (int)$this->arguments['itemsPerPage']);
@@ -90,6 +95,7 @@ final class TableViewHelper extends AbstractViewHelper
         // Never render the whole table: a page can hold tens of thousands of
         // entries, and every row costs three backend uris
         $entries = $queryBuilder
+            ->orderBy('uid')
             ->setFirstResult(($currentPage - 1) * $itemsPerPage)
             ->setMaxResults($itemsPerPage)
             ->executeQuery()
@@ -304,7 +310,7 @@ final class TableViewHelper extends AbstractViewHelper
      */
     private function pageParameterName(string $table): string
     {
-        return 'entryPage_' . substr(md5($table . '-' . ($this->arguments['filter'][0] ?? '')), 0, 8);
+        return 'entryPage_' . substr(md5($table . '-' . (string)$this->arguments['formName']), 0, 8);
     }
 
     private function renderEmptyTable(): string

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -143,6 +143,30 @@
                 <source>No saved formEntries</source>
                 <target>Keine gespeicherten Einträge</target>
             </trans-unit>
+			<trans-unit id="table.entries">
+				<source>Entries (%s)</source>
+				<target>Einträge (%s)</target>
+			</trans-unit>
+			<trans-unit id="table.actions">
+				<source>Actions</source>
+				<target>Aktionen</target>
+			</trans-unit>
+			<trans-unit id="table.noentries">
+				<source>No entries available</source>
+				<target>Keine Einträge vorhanden</target>
+			</trans-unit>
+			<trans-unit id="tx_frpformanswers_backend_templates_formentry_list.page">
+				<source>Page</source>
+				<target>Seite</target>
+			</trans-unit>
+			<trans-unit id="tx_frpformanswers_backend_templates_formentry_prepareexport.csvonly">
+				<source>Applies to the CSV export</source>
+				<target>Gilt für den CSV-Export</target>
+			</trans-unit>
+			<trans-unit id="tx_frpformanswers_backend_templates_formentry_prepareexport.header">
+				<source>Forms Export</source>
+				<target>Formular-Export</target>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -108,6 +108,24 @@
             <trans-unit id="tx_frpformanswers_backend_templates_formentry_list.nothingsaved">
                 <source>No saved formEntries</source>
             </trans-unit>
+            <trans-unit id="table.entries">
+                <source>Entries (%s)</source>
+            </trans-unit>
+            <trans-unit id="table.actions">
+                <source>Actions</source>
+            </trans-unit>
+            <trans-unit id="table.noentries">
+                <source>No entries available</source>
+            </trans-unit>
+            <trans-unit id="tx_frpformanswers_backend_templates_formentry_list.page">
+                <source>Page</source>
+            </trans-unit>
+            <trans-unit id="tx_frpformanswers_backend_templates_formentry_prepareexport.csvonly">
+                <source>Applies to the CSV export</source>
+            </trans-unit>
+            <trans-unit id="tx_frpformanswers_backend_templates_formentry_prepareexport.header">
+                <source>Forms Export</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Templates/FormEntry/List.html
+++ b/Resources/Private/Templates/FormEntry/List.html
@@ -1,6 +1,6 @@
-<html xmlns:f="http://xsd.helmut-hummel.de/ns/TYPO3/Fluid/ViewHelpers"
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
       xmlns:frp="http://typo3.org/ns/Frappant/FrpFormAnswers/ViewHelpers/Be"
-
       data-namespace-typo3-fluid="true">
 <f:layout name="Module"/>
 
@@ -11,60 +11,91 @@
     </h1>
     <f:flashMessages/>
 
-    <f:variable name="title"><f:translate key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:deleteFormName.confirmation.title" /></f:variable>
-    <f:variable name="content"><f:translate key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:deleteFormName.confirmation.content" /></f:variable>
+    <f:variable name="title"><f:translate key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:deleteFormName.confirmation.title"/></f:variable>
+    <f:variable name="content"><f:translate key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:deleteFormName.confirmation.content"/></f:variable>
+
     <f:for each="{formNames}" as="formName">
-        <f:form action="export" class="form-inline" method="POST" object="{formEntryDemand}" format="Xls"
-                objectName="formEntryDemand">
-            <f:form.hidden property="allPids" value="1"/>
-            <f:form.hidden property="uidLabel" value="uid"/>
-            <f:form.hidden property="formName" value="{formName}"/>
-            <div class="form-group">
-                <f:form.select property="selectAll" class="form-control" options="{
-                    1: '{f:translate(key:\'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.exportall\')}',
-                    0: '{f:translate(key:\'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.exportnew\')}'
-                    }"
-                />
+        <div class="panel panel-default mb-4">
+            <div class="panel-heading">
+                <h2 class="panel-title mb-0">{formName}</h2>
             </div>
-            <div class="form-group">
-                <f:form.submit class="btn btn-sm btn-default "
-                               value="{f:translate(key:'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.export')}"
-                />
+            <div class="panel-body">
+                <f:form action="export" method="POST" object="{formEntryDemand}" format="Xls"
+                        objectName="formEntryDemand">
+                    <f:form.hidden property="allPids" value="1"/>
+                    <f:form.hidden property="uidLabel" value="uid"/>
+                    <f:form.hidden property="formName" value="{formName}"/>
+                    <f:form.hidden property="fileName" value="{formName}"/>
+
+                    <div class="row g-2 align-items-end">
+                        <div class="col-auto">
+                            <label class="form-label" for="frp-selectall-{formName}">
+                                <f:translate
+                                        key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.selectedentries"/>
+                            </label>
+                            <f:form.select id="frp-selectall-{formName}" property="selectAll" class="form-select" options="{
+                                1: '{f:translate(key:\'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.exportall\')}',
+                                0: '{f:translate(key:\'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.exportnew\')}'
+                                }"/>
+                        </div>
+                        <div class="col-auto">
+                            <f:form.submit class="btn btn-default"
+                                           value="{f:translate(key:'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.export')}"/>
+                        </div>
+                        <div class="col-auto">
+                            <f:link.action action="deleteFormname" class="btn btn-danger t3js-modal-trigger"
+                                           arguments="{formName: formName}" data="{title:title,content:content}">
+                                <core:icon identifier="actions-delete" size="small"/>
+                                <f:translate
+                                        key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_show.delete"/>
+                            </f:link.action>
+                        </div>
+                    </div>
+                </f:form>
             </div>
-            <div class="form-group">
-                <f:link.action action="deleteFormname" class="btn btn-sm btn-default t3js-modal-trigger" arguments="{formName: formName}" data="{title:title,content:content}">
-                    {f:translate(key:'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_show.delete')}
-                </f:link.action>
-            </div>
-        </f:form>
-        <f:format.raw><frp:table columns="{0:'uid', 1: 'form', 2: 'crdate', 3: 'exported'}" filter="{0: 'form = \'{formName}\''}" table="tx_frpformanswers_domain_model_formentry"  pid="{pid}" /></f:format.raw>
+            <f:format.raw><frp:table columns="{0:'uid', 1: 'form', 2: 'crdate', 3: 'exported'}" filter="{0: 'form = \'{formName}\''}" table="tx_frpformanswers_domain_model_formentry" pid="{pid}"/></f:format.raw>
+        </div>
     </f:for>
+
     <f:if condition="{subPagesWithFormEntries}">
         <h2>
             <f:translate
                     key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_list.listh2"/>
         </h2>
-        <ul style="list-style-type: none;">
-            <f:for each="{subPagesWithFormEntries}" as="page">
-                <li>
-                    <core:icon identifier="apps-pagetree-page-default" size="small" /> <frp:link.beLink title="{page.title}" pageUid="{page.uid}">{page.title} ({page.uid})</frp:link.beLink>
-                     <f:for each="{formEntriesStatus.{page.uid}}" as="formData" key="formName">
-                        <li style="margin-bottom: 15px;">
-                            Form: {formName}
-                            <ul>
-                                <li><f:translate key="tx_frpformanswers_domain_model_formentry.tot" /> : <f:format.number decimals="0">{formData.tot}</f:format.number></li>
-                                <li><f:translate key="tx_frpformanswers_domain_model_formentry.new" /> : <f:format.number decimals="0">{formData.new}</f:format.number></li>
-                            </ul>
-                        </li>
+        <div class="table-fit">
+            <table class="table table-striped">
+                <thead>
+                <tr>
+                    <th><f:translate key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_list.page" default="Page"/></th>
+                    <th><f:translate key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_db.xlf:tx_frpformanswers_domain_model_formentry.form" default="Form"/></th>
+                    <th class="text-end"><f:translate key="tx_frpformanswers_domain_model_formentry.tot"/></th>
+                    <th class="text-end"><f:translate key="tx_frpformanswers_domain_model_formentry.new"/></th>
+                </tr>
+                </thead>
+                <tbody>
+                <f:for each="{subPagesWithFormEntries}" as="page">
+                    <f:for each="{formEntriesStatus.{page.uid}}" as="formData" key="formName">
+                        <tr>
+                            <td>
+                                <core:icon identifier="apps-pagetree-page-default" size="small"/>
+                                <frp:link.beLink title="{page.title}" pageUid="{page.uid}">{page.title} ({page.uid})</frp:link.beLink>
+                            </td>
+                            <td>{formName}</td>
+                            <td class="text-end"><f:format.number decimals="0">{formData.tot}</f:format.number></td>
+                            <td class="text-end"><f:format.number decimals="0">{formData.new}</f:format.number></td>
+                        </tr>
                     </f:for>
-                </li>
-            </f:for>
-        </ul>
+                </f:for>
+                </tbody>
+            </table>
+        </div>
     </f:if>
 
     <f:if condition="{subPagesWithFormEntries ->f:count()} == 0 && {formNames->f:count()} == 0">
-        <f:translate
-                key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_list.nothingsaved"/>
-
+        <div class="callout callout-info">
+            <f:translate
+                    key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_list.nothingsaved"/>
+        </div>
     </f:if>
 </f:section>
+</html>

--- a/Resources/Private/Templates/FormEntry/List.html
+++ b/Resources/Private/Templates/FormEntry/List.html
@@ -53,7 +53,7 @@
                     </div>
                 </f:form>
             </div>
-            <f:format.raw><frp:table columns="{0:'uid', 1: 'form', 2: 'crdate', 3: 'exported'}" filter="{0: 'form = \'{formName}\''}" table="tx_frpformanswers_domain_model_formentry" pid="{pid}"/></f:format.raw>
+            <frp:table columns="{0:'uid', 1: 'form', 2: 'crdate', 3: 'exported'}" formName="{formName}" table="tx_frpformanswers_domain_model_formentry" pid="{pid}"/>
         </div>
     </f:for>
 

--- a/Resources/Private/Templates/FormEntry/PrepareExport.html
+++ b/Resources/Private/Templates/FormEntry/PrepareExport.html
@@ -1,131 +1,114 @@
-<html xmlns:f="http://xsd.helmut-hummel.de/ns/TYPO3/Fluid/ViewHelpers"
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
       data-namespace-typo3-fluid="true">
 <f:layout name="Module"/>
 
 <f:section name="Content">
-    <h1>Forms Export</h1>
+    <h1><f:translate key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.header" default="Forms Export"/></h1>
     <f:flashMessages/>
+
     <f:form action="export" method="POST" object="{formEntryDemand}" objectName="formEntryDemand">
-        <table class="table table-striped table-hover">
-            <tr>
-                <td>
-                    <label class="t3js-formengine-label">
+        <div class="row">
+            <div class="col-md-6 col-xl-4">
+
+                <div class="form-group">
+                    <label class="form-label" for="frp-export-selectall">
                         <f:translate
                                 key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.selectedentries"/>
                     </label>
-                    <div class="t3js-formengine-field-item">
-                        <f:form.select property="selectAll" options="{
-                    1: '{f:translate(key:\'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.exportall\')}',
-                    0: '{f:translate(key:\'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.exportnew\')}'
-                    }"
-                        />
-                    </div>
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <label class="t3js-formengine-label">
+                    <f:form.select id="frp-export-selectall" class="form-select" property="selectAll" options="{
+                        1: '{f:translate(key:\'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.exportall\')}',
+                        0: '{f:translate(key:\'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.exportnew\')}'
+                        }"/>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="frp-export-allpids">
                         <f:translate
                                 key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.selectedfields"/>
                     </label>
-                    <div class="t3js-formengine-field-item">
-                        <f:form.select name="allPids" options="{
-                    1: '{f:translate(key:\'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.exportallpages\')}',
-                    0: '{f:translate(key:\'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.exportonlythispage\')}'
-                    }"
-                        />
-                    </div>
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <label class="t3js-formengine-label">
+                    <f:form.select id="frp-export-allpids" class="form-select" name="allPids" options="{
+                        1: '{f:translate(key:\'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.exportallpages\')}',
+                        0: '{f:translate(key:\'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.exportonlythispage\')}'
+                        }"/>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="frp-export-format">
                         <f:translate
                                 key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.fileformat"/>
                     </label>
-                    <div class="t3js-formengine-field-item">
-                        <f:form.select name="format" options="{Xls: 'Excel', Csv: 'CSV', Xml: 'XML'}"/>
-                    </div>
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <label class="t3js-formengine-label">
-                        <f:translate
-                                key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.labelforuid"/>
-                    </label>
-                    <div class="t3js-formengine-field-item">
-                        <f:form.textfield property="uidLabel" value="uid"/>
-                    </div>
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <label class="t3js-formengine-label">
+                    <f:form.select id="frp-export-format" class="form-select" name="format"
+                                   options="{Xls: 'Excel', Csv: 'CSV', Xml: 'XML'}"/>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="frp-export-filename">
                         <f:translate
                                 key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.filename"/>
                     </label>
-                    <div class="t3js-formengine-field-item">
-                        <f:form.textfield property="fileName" value="export"/>
-                    </div>
-                </td>
-            </tr>
-            <f:comment>
-            <!--<tr>
-                <td>
-                    <label class="t3js-formengine-label">
+                    <f:form.textfield id="frp-export-filename" class="form-control" property="fileName" value="export"/>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="frp-export-uidlabel">
                         <f:translate
-                                key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.form"/>
+                                key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.labelforuid"/>
                     </label>
-                    <div class="t3js-formengine-field-item">
-                        <f:form.select property="form" prependOptionLabel="
-                    {f:translate(key:'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.formnotspecified')}
-                    " options="{formHashes}"/>
-                    </div>
-                </td>
-            </tr>-->
-            </f:comment>
-            <tr class="csvExport specific_type_config">
-                <td>
-                    <label class="t3js-formengine-label">
+                    <f:form.textfield id="frp-export-uidlabel" class="form-control" property="uidLabel" value="uid"/>
+                </div>
+
+            </div>
+            <div class="col-md-6 col-xl-4">
+
+                <div class="form-group">
+                    <label class="form-label" for="frp-export-charset">
                         <f:translate
                                 key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.charset"/>
                     </label>
-                    <div class="t3js-formengine-field-item">
-                        <f:form.select options="{UTF-8: 'UTF-8', iso-8859-1: 'ISO-8859-1', UTF-16LE: 'UTF-16LE'}"
-                                       property="charset"/>
+                    <f:form.select id="frp-export-charset" class="form-select" property="charset"
+                                   options="{UTF-8: 'UTF-8', iso-8859-1: 'ISO-8859-1', UTF-16LE: 'UTF-16LE'}"/>
+                    <div class="form-text">
+                        <f:translate
+                                key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.csvonly"
+                                default="Applies to the CSV export"/>
                     </div>
-                </td>
-            </tr>
-            <tr class="csvExport specific_type_config">
-                <td>
-                    <label class="t3js-formengine-label">
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="frp-export-delimiter">
                         <f:translate
                                 key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.separator"/>
                     </label>
-                    <div class="t3js-formengine-field-item">
-                        <f:form.select options="{semikolon:';', komma: ',',tab: '[TAB]'}" property="delimiter"/>
+                    <f:form.select id="frp-export-delimiter" class="form-select" property="delimiter"
+                                   options="{semikolon: ';', komma: ',', tab: '[TAB]'}"/>
+                    <div class="form-text">
+                        <f:translate
+                                key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.csvonly"
+                                default="Applies to the CSV export"/>
                     </div>
-                </td>
-            </tr>
-            <tr class="csvExport specific_type_config">
-                <td>
-                    <label class="t3js-formengine-label">
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label" for="frp-export-enclosure">
                         <f:translate
                                 key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.textseparator"/>
                     </label>
-                    <div class="t3js-formengine-field-item">
-                        <f:form.select options="{double: '\"
-                        ', single: '\''}" property="enclosure" />
+                    <f:form.select id="frp-export-enclosure" class="form-select" property="enclosure"
+                                   options="{double: '\"', single: '\''}"/>
+                    <div class="form-text">
+                        <f:translate
+                                key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.csvonly"
+                                default="Applies to the CSV export"/>
                     </div>
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <f:form.submit class="btn btn-sm btn-default "
-                                   value="{f:translate(key:'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.export')}"/>
-                </td>
-            </tr>
-        </table>
+                </div>
+
+            </div>
+        </div>
+
+        <div class="mt-3">
+            <f:form.submit class="btn btn-primary"
+                           value="{f:translate(key:'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareexport.export')}"/>
+        </div>
     </f:form>
 </f:section>
+</html>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -19,5 +19,7 @@ CREATE TABLE tx_frpformanswers_domain_model_formentry (
 
 	PRIMARY KEY (uid),
 	KEY parent (pid),
+	KEY pid_deleted_form (pid, deleted, form, exported),
+	KEY form_submit (form, deleted, submit_uid),
 
 );


### PR DESCRIPTION
Stacked on #93 — review that one first, this PR targets its branch so the diff stays clean. It will retarget to `master` automatically once #93 merges.

## Large data sets — refs #54

Reproduced the report first. With **34 000 entries** seeded on one page, the module died before rendering anything:

> Fatal error: Allowed memory size of 134217728 bytes exhausted in `AbstractDomainObject.php`

Causes and fixes:

* The overview counted entries by **loading every one of them as an Extbase object** and counting in PHP — twice, because the form names and hashes were collected the same way. Counting is a grouped query now, the names come from a distinct query.
* The entry table fetched and rendered **every row**, each costing three backend URI builds. It pages instead — 50 per page, with its own page parameter per table, so paging one form does not move the others. The URI shared by all rows is built once.
* The export hydrated the whole result set and held it while writing. Entries are read in **chunks of 500** with the persistence session cleared per chunk, and the uids to flag are collected on the way.
* The Excel writer keeps its cells in a filesystem cache (`symfony/cache`, already a TYPO3 dependency).

Measured on TYPO3 14.3.6 at PHP's default 128M limit with 34 000 entries:

| | before | after |
|---|---|---|
| module list | fatal, memory exhausted | renders in 0.1 s, 0.36 MB html |
| CSV export | fatal | 8.5 MB in 1.5 s |
| XML export | fatal | 13.9 MB in 1.5 s |
| Excel export | fatal above ~2 000 entries | 10 000 entries ok; 34 000 still needs more than 128M |

#54 stays open for the Excel case — PhpSpreadsheet needs a streaming writer for that, which is a bigger change.

## Backend styling

The module built its forms from table rows with `t3js-formengine-*` class names, which only do something inside FormEngine — that is why the export screen looked unlike the rest of the backend. Both screens now use the same `form-group` / `form-label` / `form-select` / `form-control` markup core uses in its own modules: the export settings sit in two columns with a hint on the csv-only options, each form on the overview gets a panel with its own heading and a proper delete button, and the subpage overview is a table instead of a nested bullet list.

The entry table's hardcoded strings (heading, actions column, and the German "Keine Einträge vorhanden") now come from the language files, with German translations added.

## Also fixed, found during the UAT

The quick export on the overview submits no delimiter or text separator, so a CSV export started from there passed `null` into `fputcsv2()` and ended in a `TypeError`. It falls back to the defaults now. The quick export also names the file after the form instead of `export.xlsx`.

## Verification

Full manual pass on TYPO3 14.3.6 / PHP 8.4 with 34 000 entries plus an edge-case row (umlauts, a `=SUM(1,2)` value, a StaticText field): module list and per-table paging, record view, all three export formats from both the export screen and the per-form quick export, both charsets, custom file names, export-only-new semantics, delete flows including the German flash messages, ultimate delete, and the CLI mail command. Gates: PHPUnit 7/7, PHPStan level 6 clean, php-cs-fixer clean.

The seeder used for the measurements is not part of the extension; it is a throwaway script that writes entries straight into the database.