### PR TITLE
[BUGFIX] Read every submitted value, including paths and multiple files (#69, #47)

### DIFF
--- a/Classes/Domain/Finishers/SaveFormToDatabaseFinisher.php
+++ b/Classes/Domain/Finishers/SaveFormToDatabaseFinisher.php
@@ -114,6 +114,16 @@ class SaveFormToDatabaseFinisher extends AbstractFinisher
             return null;
         }
 
+        // An identifier that is stored as it is wins, so the usual case keeps
+        // working exactly as before
+        if (array_key_exists($identifier, $submittedValues)) {
+            return $submittedValues[$identifier];
+        }
+
+        if ($identifier === '' || !str_contains($identifier, '.')) {
+            return null;
+        }
+
         try {
             return ArrayUtility::getValueByPath($submittedValues, $identifier, '.');
         } catch (MissingArrayPathException) {

--- a/Classes/Domain/Finishers/SaveFormToDatabaseFinisher.php
+++ b/Classes/Domain/Finishers/SaveFormToDatabaseFinisher.php
@@ -7,9 +7,9 @@ use Frappant\FrpFormAnswers\Domain\Repository\FormEntryRepository;
 use Frappant\FrpFormAnswers\Event\ManipulateFormValuesEvent;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
+use TYPO3\CMS\Core\Resource\FileInterface;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\Exception\MissingArrayPathException;
-use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 use TYPO3\CMS\Form\Domain\Finishers\AbstractFinisher;
 use TYPO3\CMS\Form\Domain\Model\FormElements\FormElementInterface;
@@ -136,14 +136,22 @@ class SaveFormToDatabaseFinisher extends AbstractFinisher
      * accepts multiple files - those arrive as an ObjectStorage of file
      * references instead of a single one.
      *
-     * @return string|list<string>|null
+     * An element without a file gives an empty list rather than null, so that
+     * consumers of the stored values - the upload path enrichment among them -
+     * always see a string or a list. Anything that does not resolve to a file
+     * name is left out of that list.
+     *
+     * @return string|list<string>
      */
-    private function getUploadedFileNames(mixed $upload): string|array|null
+    private function getUploadedFileNames(mixed $upload): string|array
     {
-        if ($upload instanceof FileReference || (is_object($upload) && method_exists($upload, 'getOriginalResource'))) {
-            $resource = $upload->getOriginalResource();
+        // Same order as the core finishers use when they read an upload
+        if (is_object($upload) && method_exists($upload, 'getOriginalResource')) {
+            $upload = $upload->getOriginalResource();
+        }
 
-            return is_object($resource) && method_exists($resource, 'getName') ? $resource->getName() : null;
+        if ($upload instanceof FileInterface) {
+            return $upload->getName();
         }
 
         if (is_iterable($upload)) {
@@ -158,7 +166,7 @@ class SaveFormToDatabaseFinisher extends AbstractFinisher
             return $names;
         }
 
-        return null;
+        return [];
     }
 
     /**

--- a/Classes/Domain/Finishers/SaveFormToDatabaseFinisher.php
+++ b/Classes/Domain/Finishers/SaveFormToDatabaseFinisher.php
@@ -7,6 +7,9 @@ use Frappant\FrpFormAnswers\Domain\Repository\FormEntryRepository;
 use Frappant\FrpFormAnswers\Event\ManipulateFormValuesEvent;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
+use TYPO3\CMS\Core\Utility\Exception\MissingArrayPathException;
+use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 use TYPO3\CMS\Form\Domain\Finishers\AbstractFinisher;
 use TYPO3\CMS\Form\Domain\Model\FormElements\FormElementInterface;
@@ -78,24 +81,74 @@ class SaveFormToDatabaseFinisher extends AbstractFinisher
         // Goes trough all form-pages - and there trough all PageElements (Questions)
         foreach ($this->finisherContext->getFormRuntime()->getPages() as $page) {
             foreach ($page->getElementsRecursively() as $pageElem) {
-                if ($pageElem->getType() !== 'Honeypot') {
-                    if ($pageElem->getType() !== 'FileUpload' && $pageElem->getType() !== 'ImageUpload') {
-                        $values[$pageElem->getIdentifier()]['value'] = $valuesWithPages[$pageElem->getIdentifier()] ?? null;
-                    } else {
-                        $upload = $valuesWithPages[$pageElem->getIdentifier()] ?? null;
-                        if (is_object($upload) && method_exists($upload, 'getOriginalResource')) {
-                            $resource = $upload->getOriginalResource();
-                            if (is_object($resource) && method_exists($resource, 'getName')) {
-                                $values[$pageElem->getIdentifier()]['value'] = $resource->getName();
-                            }
-                        }
-                    }
-                    $values[$pageElem->getIdentifier()]['conf']['label'] = $pageElem->getLabel();
-                    $values[$pageElem->getIdentifier()]['conf']['inputType'] = $pageElem->getType();
+                if ($pageElem->getType() === 'Honeypot') {
+                    continue;
                 }
+
+                $identifier = $pageElem->getIdentifier();
+                $submittedValue = $this->getSubmittedValue($valuesWithPages, $identifier);
+
+                if ($pageElem->getType() === 'FileUpload' || $pageElem->getType() === 'ImageUpload') {
+                    $values[$identifier]['value'] = $this->getUploadedFileNames($submittedValue);
+                } else {
+                    $values[$identifier]['value'] = $submittedValue;
+                }
+
+                $values[$identifier]['conf']['label'] = $pageElem->getLabel();
+                $values[$identifier]['conf']['inputType'] = $pageElem->getType();
             }
         }
         return $values;
+    }
+
+    /**
+     * Reads one submitted value.
+     *
+     * Element identifiers can contain dots, and the form framework stores the
+     * values by that path (a "foo.0.bar" element lives in
+     * $values['foo'][0]['bar']), so a flat lookup would miss them.
+     */
+    private function getSubmittedValue(mixed $submittedValues, string $identifier): mixed
+    {
+        if (!is_array($submittedValues)) {
+            return null;
+        }
+
+        try {
+            return ArrayUtility::getValueByPath($submittedValues, $identifier, '.');
+        } catch (MissingArrayPathException) {
+            return null;
+        }
+    }
+
+    /**
+     * The name of the uploaded file, or a list of names when the element
+     * accepts multiple files - those arrive as an ObjectStorage of file
+     * references instead of a single one.
+     *
+     * @return string|list<string>|null
+     */
+    private function getUploadedFileNames(mixed $upload): string|array|null
+    {
+        if ($upload instanceof FileReference || (is_object($upload) && method_exists($upload, 'getOriginalResource'))) {
+            $resource = $upload->getOriginalResource();
+
+            return is_object($resource) && method_exists($resource, 'getName') ? $resource->getName() : null;
+        }
+
+        if (is_iterable($upload)) {
+            $names = [];
+            foreach ($upload as $file) {
+                $name = $this->getUploadedFileNames($file);
+                if (is_string($name) && $name !== '') {
+                    $names[] = $name;
+                }
+            }
+
+            return $names;
+        }
+
+        return null;
     }
 
     /**

--- a/Classes/EventListener/UploadPathEnrichmentEventListener.php
+++ b/Classes/EventListener/UploadPathEnrichmentEventListener.php
@@ -52,7 +52,9 @@ final class UploadPathEnrichmentEventListener
             $entry = $values[$fieldIdentifier];
 
             // Expect documented structure: ['value' => string|array, 'conf' => ...]
-            if (is_array($entry) && array_key_exists('value', $entry)) {
+            // Anything else - an element without a file, or a value another
+            // listener replaced - is left untouched
+            if (is_array($entry) && (is_string($entry['value'] ?? null) || is_array($entry['value'] ?? null))) {
 
                 // Determine final prefix per file (handles form_<hash> folder)
                 $entry['value'] = $this->prependWithSubmissionPrefix(

--- a/Classes/EventListener/UploadPathEnrichmentEventListener.php
+++ b/Classes/EventListener/UploadPathEnrichmentEventListener.php
@@ -52,8 +52,8 @@ final class UploadPathEnrichmentEventListener
             $entry = $values[$fieldIdentifier];
 
             // Expect documented structure: ['value' => string|array, 'conf' => ...]
-            // Anything else - an element without a file, or a value another
-            // listener replaced - is left untouched
+            // A value another listener replaced by something that is no file
+            // name is left untouched
             if (is_array($entry) && (is_string($entry['value'] ?? null) || is_array($entry['value'] ?? null))) {
 
                 // Determine final prefix per file (handles form_<hash> folder)

--- a/Classes/Form/FormAnswersJsonElement.php
+++ b/Classes/Form/FormAnswersJsonElement.php
@@ -20,26 +20,18 @@ class FormAnswersJsonElement extends AbstractFormElement
 
         if (is_array($fieldValues)) {
             foreach ($fieldValues as $fieldKey => $fieldValue) {
-                if ($fieldValue['conf']['label']) {
-                    $out .= '<li>' .
-                        htmlspecialchars($fieldValue['conf']['label']) .
-                        ' - ' .
-                        htmlspecialchars(
-                            is_array($fieldValue['value']) ? implode(',', $fieldValue['value']) : $fieldValue['value']
-                        )
-                        .
-                        '</li>'
-                    ;
-                } else {
-                    $out .= '<li>' .
-                        htmlspecialchars($fieldKey) .
-                        ' - ' .
-                        htmlspecialchars(
-                            is_array($fieldValue['value']) ? implode(',', $fieldValue['value']) : $fieldValue['value']
-                        ) .
-                        '</li>'
-                    ;
-                }
+                // Entries saved by an older version can miss the value
+                // altogether, and an unanswered field has none
+                $value = $fieldValue['value'] ?? '';
+                $value = is_array($value) ? implode(',', $value) : (string)$value;
+                $label = $fieldValue['conf']['label'] ?? '';
+
+                $out .= '<li>' .
+                    htmlspecialchars($label !== '' ? $label : $fieldKey) .
+                    ' - ' .
+                    htmlspecialchars($value) .
+                    '</li>'
+                ;
             }
         }
         $out .= '</ul>';

--- a/Classes/Form/FormAnswersJsonElement.php
+++ b/Classes/Form/FormAnswersJsonElement.php
@@ -21,13 +21,14 @@ class FormAnswersJsonElement extends AbstractFormElement
         if (is_array($fieldValues)) {
             foreach ($fieldValues as $fieldKey => $fieldValue) {
                 // Entries saved by an older version can miss the value
-                // altogether, and an unanswered field has none
-                $value = $fieldValue['value'] ?? '';
-                $value = is_array($value) ? implode(',', $value) : (string)$value;
-                $label = $fieldValue['conf']['label'] ?? '';
+                // altogether, and an unanswered field has none. A listener on
+                // ManipulateFormValuesEvent may put anything in either of the
+                // two, so neither is trusted to be a string.
+                $label = $this->flatten($fieldValue['conf']['label'] ?? '');
+                $value = $this->flatten($fieldValue['value'] ?? '');
 
                 $out .= '<li>' .
-                    htmlspecialchars($label !== '' ? $label : $fieldKey) .
+                    htmlspecialchars($label !== '' ? $label : (string)$fieldKey) .
                     ' - ' .
                     htmlspecialchars($value) .
                     '</li>'
@@ -38,5 +39,24 @@ class FormAnswersJsonElement extends AbstractFormElement
 
         $resultArray['html'] = $out;
         return $resultArray;
+    }
+
+    /**
+     * One line of text for whatever json_decode() gave us: a list of values
+     * becomes a comma separated list, and anything that carries no text of its
+     * own is left empty instead of ending up as the word "Array".
+     */
+    private function flatten(mixed $value): string
+    {
+        if (is_array($value)) {
+            $parts = [];
+            foreach ($value as $item) {
+                $parts[] = $this->flatten($item);
+            }
+
+            return implode(',', $parts);
+        }
+
+        return is_scalar($value) ? (string)$value : '';
     }
 }

--- a/Tests/Unit/Domain/Finishers/FormValueExtractionTest.php
+++ b/Tests/Unit/Domain/Finishers/FormValueExtractionTest.php
@@ -129,7 +129,7 @@ class FormValueExtractionTest extends UnitTestCase
     }
 
     #[Test]
-    public function everyElementOfEveryPageIsCollected(): void
+    public function everyElementIsCollectedWithItsLabelAndTypeExceptTheHoneypot(): void
     {
         $storage = new ObjectStorage();
         $storage->attach($this->createFileReference('first.pdf'));

--- a/Tests/Unit/Domain/Finishers/FormValueExtractionTest.php
+++ b/Tests/Unit/Domain/Finishers/FormValueExtractionTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Frappant\FrpFormAnswers\Tests\Unit\Domain\Finishers;
+
+use Frappant\FrpFormAnswers\Domain\Finishers\SaveFormToDatabaseFinisher;
+use Frappant\FrpFormAnswers\Domain\Model\FormEntry;
+use Frappant\FrpFormAnswers\Domain\Repository\FormEntryRepository;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\Resource\FileReference as CoreFileReference;
+use TYPO3\CMS\Extbase\Domain\Model\FileReference;
+use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
+use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * How submitted values are read out of the form runtime.
+ */
+class FormValueExtractionTest extends UnitTestCase
+{
+    private SaveFormToDatabaseFinisher $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new SaveFormToDatabaseFinisher(
+            $this->createMock(EventDispatcherInterface::class),
+            $this->createMock(FormEntryRepository::class),
+            new FormEntry(),
+            $this->createMock(PersistenceManager::class),
+        );
+    }
+
+    /**
+     * @return array<string, array{0: array<string, mixed>, 1: string, 2: mixed}>
+     */
+    public static function submittedValueDataProvider(): array
+    {
+        return [
+            'plain identifier' => [
+                ['name' => 'Ada'],
+                'name',
+                'Ada',
+            ],
+            'identifier with a dot is read as a path' => [
+                ['container' => [0 => ['street' => 'Bahnhofstrasse']]],
+                'container.0.street',
+                'Bahnhofstrasse',
+            ],
+            'missing identifier yields null' => [
+                ['name' => 'Ada'],
+                'missing',
+                null,
+            ],
+            'missing path segment yields null' => [
+                ['container' => [0 => ['street' => 'Bahnhofstrasse']]],
+                'container.1.street',
+                null,
+            ],
+            'value that is itself an array is kept' => [
+                ['choices' => ['a', 'b']],
+                'choices',
+                ['a', 'b'],
+            ],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('submittedValueDataProvider')]
+    public function submittedValuesAreReadByPropertyPath(array $submitted, string $identifier, mixed $expected): void
+    {
+        self::assertSame($expected, $this->callGetSubmittedValue($submitted, $identifier));
+    }
+
+    #[Test]
+    public function singleUploadIsReducedToItsFileName(): void
+    {
+        self::assertSame('letter.pdf', $this->callGetUploadedFileNames($this->createFileReference('letter.pdf')));
+    }
+
+    #[Test]
+    public function multipleUploadsAreReducedToAListOfFileNames(): void
+    {
+        $storage = new ObjectStorage();
+        $storage->attach($this->createFileReference('first.pdf'));
+        $storage->attach($this->createFileReference('second.pdf'));
+
+        self::assertSame(['first.pdf', 'second.pdf'], $this->callGetUploadedFileNames($storage));
+    }
+
+    #[Test]
+    public function emptyUploadYieldsNull(): void
+    {
+        self::assertNull($this->callGetUploadedFileNames(null));
+    }
+
+    #[Test]
+    public function emptyMultipleUploadYieldsAnEmptyList(): void
+    {
+        self::assertSame([], $this->callGetUploadedFileNames(new ObjectStorage()));
+    }
+
+    private function createFileReference(string $name): FileReference
+    {
+        $originalResource = $this->createMock(CoreFileReference::class);
+        $originalResource->method('getName')->willReturn($name);
+
+        $fileReference = $this->createMock(FileReference::class);
+        $fileReference->method('getOriginalResource')->willReturn($originalResource);
+
+        return $fileReference;
+    }
+
+    /**
+     * @param array<string, mixed> $submitted
+     */
+    private function callGetSubmittedValue(array $submitted, string $identifier): mixed
+    {
+        $method = new \ReflectionMethod(SaveFormToDatabaseFinisher::class, 'getSubmittedValue');
+
+        return $method->invoke($this->subject, $submitted, $identifier);
+    }
+
+    private function callGetUploadedFileNames(mixed $upload): string|array|null
+    {
+        $method = new \ReflectionMethod(SaveFormToDatabaseFinisher::class, 'getUploadedFileNames');
+
+        return $method->invoke($this->subject, $upload);
+    }
+}

--- a/Tests/Unit/Domain/Finishers/FormValueExtractionTest.php
+++ b/Tests/Unit/Domain/Finishers/FormValueExtractionTest.php
@@ -116,9 +116,10 @@ class FormValueExtractionTest extends UnitTestCase
     }
 
     #[Test]
-    public function emptyUploadYieldsNull(): void
+    public function emptyUploadYieldsAnEmptyList(): void
     {
-        self::assertNull($this->callGetUploadedFileNames(null));
+        // Not null: the upload path enrichment takes a string or a list
+        self::assertSame([], $this->callGetUploadedFileNames(null));
     }
 
     #[Test]
@@ -170,6 +171,58 @@ class FormValueExtractionTest extends UnitTestCase
         self::assertNull($values['optional']['value']);
     }
 
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function uploadElementTypeDataProvider(): array
+    {
+        return [
+            'file upload' => ['FileUpload'],
+            'image upload' => ['ImageUpload'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('uploadElementTypeDataProvider')]
+    public function anUploadElementWithoutAFileYieldsAnEmptyList(string $type): void
+    {
+        // The form runtime writes the key with a null value when the visitor
+        // leaves an optional upload empty
+        $values = $this->callGetFormValues(
+            [$this->createElement('attachment', $type, 'Attachment')],
+            ['attachment' => null],
+        );
+
+        self::assertSame([], $values['attachment']['value']);
+    }
+
+    #[Test]
+    #[DataProvider('uploadElementTypeDataProvider')]
+    public function anUploadElementOfEitherTypeIsReducedToItsFileName(string $type): void
+    {
+        $values = $this->callGetFormValues(
+            [$this->createElement('attachment', $type, 'Attachment')],
+            ['attachment' => $this->createFileReference('letter.pdf')],
+        );
+
+        self::assertSame('letter.pdf', $values['attachment']['value']);
+    }
+
+    #[Test]
+    public function elementsOfEveryPageAreCollected(): void
+    {
+        $values = $this->callGetFormValuesForPages(
+            [
+                [$this->createElement('first', 'Text', 'First')],
+                [$this->createElement('second', 'Text', 'Second')],
+            ],
+            ['first' => 'one', 'second' => 'two'],
+        );
+
+        self::assertSame(['first', 'second'], array_keys($values));
+        self::assertSame('two', $values['second']['value']);
+    }
+
     private function createElement(string $identifier, string $type, string $label): FormElementInterface
     {
         $element = $this->createMock(FormElementInterface::class);
@@ -187,11 +240,25 @@ class FormValueExtractionTest extends UnitTestCase
      */
     private function callGetFormValues(array $elements, array $submitted): array
     {
-        $page = $this->createMock(Page::class);
-        $page->method('getElementsRecursively')->willReturn($elements);
+        return $this->callGetFormValuesForPages([$elements], $submitted);
+    }
+
+    /**
+     * @param list<list<FormElementInterface>> $pages
+     * @param array<string, mixed> $submitted
+     * @return array<string, array{value: mixed, conf: array{label: mixed, inputType: string}}>
+     */
+    private function callGetFormValuesForPages(array $pages, array $submitted): array
+    {
+        $pageMocks = [];
+        foreach ($pages as $elements) {
+            $page = $this->createMock(Page::class);
+            $page->method('getElementsRecursively')->willReturn($elements);
+            $pageMocks[] = $page;
+        }
 
         $formRuntime = $this->createMock(FormRuntime::class);
-        $formRuntime->method('getPages')->willReturn([$page]);
+        $formRuntime->method('getPages')->willReturn($pageMocks);
 
         $finisherContext = $this->createMock(FinisherContext::class);
         $finisherContext->method('getFormValues')->willReturn($submitted);
@@ -226,7 +293,7 @@ class FormValueExtractionTest extends UnitTestCase
         return $method->invoke($this->subject, $submitted, $identifier);
     }
 
-    private function callGetUploadedFileNames(mixed $upload): string|array|null
+    private function callGetUploadedFileNames(mixed $upload): string|array
     {
         $method = new \ReflectionMethod(SaveFormToDatabaseFinisher::class, 'getUploadedFileNames');
 

--- a/Tests/Unit/Domain/Finishers/FormValueExtractionTest.php
+++ b/Tests/Unit/Domain/Finishers/FormValueExtractionTest.php
@@ -69,6 +69,26 @@ class FormValueExtractionTest extends UnitTestCase
                 'choices',
                 ['a', 'b'],
             ],
+            'empty identifier yields null instead of throwing' => [
+                ['name' => 'Ada'],
+                '',
+                null,
+            ],
+            'identifier stored flat wins over path traversal' => [
+                ['container.0.street' => 'flat value', 'container' => [0 => ['street' => 'path value']]],
+                'container.0.street',
+                'flat value',
+            ],
+            'identifier containing a quote is not parsed as csv' => [
+                ['say "hi"' => 'quoted'],
+                'say "hi"',
+                'quoted',
+            ],
+            'null value is preserved' => [
+                ['name' => null],
+                'name',
+                null,
+            ],
         ];
     }
 

--- a/Tests/Unit/Domain/Finishers/FormValueExtractionTest.php
+++ b/Tests/Unit/Domain/Finishers/FormValueExtractionTest.php
@@ -12,6 +12,11 @@ use TYPO3\CMS\Core\Resource\FileReference as CoreFileReference;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
+use TYPO3\CMS\Form\Domain\Finishers\AbstractFinisher;
+use TYPO3\CMS\Form\Domain\Finishers\FinisherContext;
+use TYPO3\CMS\Form\Domain\Model\FormElements\FormElementInterface;
+use TYPO3\CMS\Form\Domain\Model\FormElements\Page;
+use TYPO3\CMS\Form\Domain\Runtime\FormRuntime;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
 /**
@@ -100,6 +105,84 @@ class FormValueExtractionTest extends UnitTestCase
     public function emptyMultipleUploadYieldsAnEmptyList(): void
     {
         self::assertSame([], $this->callGetUploadedFileNames(new ObjectStorage()));
+    }
+
+    #[Test]
+    public function everyElementOfEveryPageIsCollected(): void
+    {
+        $storage = new ObjectStorage();
+        $storage->attach($this->createFileReference('first.pdf'));
+        $storage->attach($this->createFileReference('second.pdf'));
+
+        $elements = [
+            $this->createElement('fullname', 'Text', 'Full name'),
+            $this->createElement('container.0.street', 'Text', 'Street'),
+            $this->createElement('attachment', 'FileUpload', 'Attachment'),
+            $this->createElement('trap', 'Honeypot', 'Honeypot'),
+        ];
+
+        $submitted = [
+            'fullname' => 'Ada',
+            'container' => [0 => ['street' => 'Bahnhofstrasse']],
+            'attachment' => $storage,
+            'trap' => 'should not be stored',
+        ];
+
+        $values = $this->callGetFormValues($elements, $submitted);
+
+        self::assertSame(['fullname', 'container.0.street', 'attachment'], array_keys($values));
+        self::assertSame('Ada', $values['fullname']['value']);
+        self::assertSame('Bahnhofstrasse', $values['container.0.street']['value']);
+        self::assertSame(['first.pdf', 'second.pdf'], $values['attachment']['value']);
+        self::assertSame('Attachment', $values['attachment']['conf']['label']);
+        self::assertSame('FileUpload', $values['attachment']['conf']['inputType']);
+    }
+
+    #[Test]
+    public function elementsWithoutASubmittedValueKeepTheValueKey(): void
+    {
+        $values = $this->callGetFormValues(
+            [$this->createElement('optional', 'Text', 'Optional')],
+            [],
+        );
+
+        self::assertArrayHasKey('value', $values['optional']);
+        self::assertNull($values['optional']['value']);
+    }
+
+    private function createElement(string $identifier, string $type, string $label): FormElementInterface
+    {
+        $element = $this->createMock(FormElementInterface::class);
+        $element->method('getIdentifier')->willReturn($identifier);
+        $element->method('getType')->willReturn($type);
+        $element->method('getLabel')->willReturn($label);
+
+        return $element;
+    }
+
+    /**
+     * @param list<FormElementInterface> $elements
+     * @param array<string, mixed> $submitted
+     * @return array<string, array{value: mixed, conf: array{label: mixed, inputType: string}}>
+     */
+    private function callGetFormValues(array $elements, array $submitted): array
+    {
+        $page = $this->createMock(Page::class);
+        $page->method('getElementsRecursively')->willReturn($elements);
+
+        $formRuntime = $this->createMock(FormRuntime::class);
+        $formRuntime->method('getPages')->willReturn([$page]);
+
+        $finisherContext = $this->createMock(FinisherContext::class);
+        $finisherContext->method('getFormValues')->willReturn($submitted);
+        $finisherContext->method('getFormRuntime')->willReturn($formRuntime);
+
+        $contextProperty = new \ReflectionProperty(AbstractFinisher::class, 'finisherContext');
+        $contextProperty->setValue($this->subject, $finisherContext);
+
+        $method = new \ReflectionMethod(SaveFormToDatabaseFinisher::class, 'getFormValues');
+
+        return $method->invoke($this->subject);
     }
 
     private function createFileReference(string $name): FileReference

--- a/Tests/Unit/EventListener/UploadPathEnrichmentEventListenerTest.php
+++ b/Tests/Unit/EventListener/UploadPathEnrichmentEventListenerTest.php
@@ -55,6 +55,35 @@ class UploadPathEnrichmentEventListenerTest extends UnitTestCase
         self::assertSame($value, $event->getValues()['attachment']['value']);
     }
 
+    #[Test]
+    public function aFileNameIsPrefixedWithItsTarget(): void
+    {
+        $event = $this->dispatch([
+            'attachment' => [
+                'value' => 'letter.pdf',
+                'conf' => ['label' => 'Attachment', 'inputType' => 'FileUpload'],
+            ],
+        ]);
+
+        self::assertSame('1:/user_upload/letter.pdf', $event->getValues()['attachment']['value']);
+    }
+
+    #[Test]
+    public function everyFileNameOfAMultipleUploadIsPrefixed(): void
+    {
+        $event = $this->dispatch([
+            'attachment' => [
+                'value' => ['first.pdf', 'second.pdf'],
+                'conf' => ['label' => 'Attachment', 'inputType' => 'FileUpload'],
+            ],
+        ]);
+
+        self::assertSame(
+            ['1:/user_upload/first.pdf', '1:/user_upload/second.pdf'],
+            $event->getValues()['attachment']['value'],
+        );
+    }
+
     /**
      * @param array<string, mixed> $values
      */

--- a/Tests/Unit/EventListener/UploadPathEnrichmentEventListenerTest.php
+++ b/Tests/Unit/EventListener/UploadPathEnrichmentEventListenerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frappant\FrpFormAnswers\Tests\Unit\EventListener;
+
+use Frappant\FrpFormAnswers\Event\ManipulateFormValuesEvent;
+use Frappant\FrpFormAnswers\EventListener\UploadPathEnrichmentEventListener;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
+use TYPO3\CMS\Core\Resource\ResourceFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Form\Domain\Model\FormDefinition;
+use TYPO3\CMS\Form\Domain\Model\FormElements\FormElementInterface;
+use TYPO3\CMS\Form\Domain\Model\FormElements\Page;
+use TYPO3\CMS\Form\Domain\Runtime\FormRuntime;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * What the listener does with the values it is handed.
+ */
+class UploadPathEnrichmentEventListenerTest extends UnitTestCase
+{
+    /**
+     * @return array<string, array{0: mixed}>
+     */
+    public static function valuesThatCarryNoFileNameDataProvider(): array
+    {
+        return [
+            'no file was uploaded' => [null],
+            'value replaced by an object' => [new \stdClass()],
+            'value replaced by a number' => [42],
+        ];
+    }
+
+    /**
+     * An upload element without a file used to be missing from the values
+     * altogether. It is written now, so the listener has to cope with a value
+     * it cannot prefix instead of running into a type error.
+     */
+    #[Test]
+    #[DataProvider('valuesThatCarryNoFileNameDataProvider')]
+    public function aValueThatIsNoFileNameIsLeftUntouched(mixed $value): void
+    {
+        $values = [
+            'attachment' => [
+                'value' => $value,
+                'conf' => ['label' => 'Attachment', 'inputType' => 'FileUpload'],
+            ],
+        ];
+
+        $event = $this->dispatch($values);
+
+        self::assertSame($value, $event->getValues()['attachment']['value']);
+    }
+
+    /**
+     * @param array<string, mixed> $values
+     */
+    private function dispatch(array $values): ManipulateFormValuesEvent
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
+        $extensionConfiguration->method('get')->willReturn([
+            'enableUploadPathEnrichment' => '1',
+            'savePublicUploadPath' => '0',
+        ]);
+        GeneralUtility::addInstance(ExtensionConfiguration::class, $extensionConfiguration);
+
+        $element = $this->createMock(FormElementInterface::class);
+        $element->method('getIdentifier')->willReturn('attachment');
+        $element->method('getType')->willReturn('FileUpload');
+        $element->method('getProperties')->willReturn(['saveToFileMount' => '1:/user_upload/']);
+
+        $page = $this->createMock(Page::class);
+        $page->method('getElementsRecursively')->willReturn([$element]);
+
+        $formDefinition = $this->createMock(FormDefinition::class);
+        $formDefinition->method('getPages')->willReturn([$page]);
+
+        $formRuntime = $this->createMock(FormRuntime::class);
+        $formRuntime->method('getFormDefinition')->willReturn($formDefinition);
+
+        $event = new ManipulateFormValuesEvent($values, $formRuntime);
+
+        (new UploadPathEnrichmentEventListener($this->createMock(ResourceFactory::class)))($event);
+
+        return $event;
+    }
+}

--- a/Tests/Unit/Form/FormAnswersJsonElementTest.php
+++ b/Tests/Unit/Form/FormAnswersJsonElementTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frappant\FrpFormAnswers\Tests\Unit\Form;
+
+use Frappant\FrpFormAnswers\Form\FormAnswersJsonElement;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * How a stored entry is rendered in the record view.
+ */
+class FormAnswersJsonElementTest extends UnitTestCase
+{
+    #[Test]
+    public function everyAnsweredFieldIsListedWithItsLabel(): void
+    {
+        $html = $this->render([
+            'fullname' => ['value' => 'Ada', 'conf' => ['label' => 'Full name', 'inputType' => 'Text']],
+            'attachment' => ['value' => ['a.pdf', 'b.pdf'], 'conf' => ['label' => 'Attachment', 'inputType' => 'FileUpload']],
+        ]);
+
+        self::assertSame('<ul><li>Full name - Ada</li><li>Attachment - a.pdf,b.pdf</li></ul>', $html);
+    }
+
+    /**
+     * @return array<string, array{0: array<string, mixed>, 1: string}>
+     */
+    public static function unusualEntryDataProvider(): array
+    {
+        return [
+            'entry saved before the value key was always written' => [
+                ['attachment' => ['conf' => ['label' => 'Attachment', 'inputType' => 'FileUpload']]],
+                '<ul><li>Attachment - </li></ul>',
+            ],
+            'field the visitor did not answer' => [
+                ['street' => ['value' => null, 'conf' => ['label' => 'Street', 'inputType' => 'Text']]],
+                '<ul><li>Street - </li></ul>',
+            ],
+            'upload without a file' => [
+                ['attachment' => ['value' => [], 'conf' => ['label' => 'Attachment', 'inputType' => 'FileUpload']]],
+                '<ul><li>Attachment - </li></ul>',
+            ],
+            'field without a label falls back to its identifier' => [
+                ['street' => ['value' => 'Bahnhofstrasse', 'conf' => ['inputType' => 'Text']]],
+                '<ul><li>street - Bahnhofstrasse</li></ul>',
+            ],
+            'label that is not a string falls back to the identifier' => [
+                ['street' => ['value' => 'Bahnhofstrasse', 'conf' => ['label' => [], 'inputType' => 'Text']]],
+                '<ul><li>street - Bahnhofstrasse</li></ul>',
+            ],
+            'value nested one level deeper' => [
+                ['street' => ['value' => ['a', ['b']], 'conf' => ['label' => 'Street', 'inputType' => 'Text']]],
+                '<ul><li>Street - a,b</li></ul>',
+            ],
+            'answers that are no json object at all' => [
+                [],
+                '<ul></ul>',
+            ],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('unusualEntryDataProvider')]
+    public function anEntryThatCarriesNoUsableTextStillRenders(array $answers, string $expected): void
+    {
+        self::assertSame($expected, $this->render($answers));
+    }
+
+    #[Test]
+    public function labelAndValueAreEscaped(): void
+    {
+        $html = $this->render([
+            'x' => ['value' => '<script>', 'conf' => ['label' => 'A & B', 'inputType' => 'Text']],
+        ]);
+
+        self::assertSame('<ul><li>A &amp; B - &lt;script&gt;</li></ul>', $html);
+    }
+
+    /**
+     * @param array<string, mixed> $answers
+     */
+    private function render(array $answers): string
+    {
+        $subject = new FormAnswersJsonElement();
+        $subject->setData(['databaseRow' => ['answers' => json_encode($answers)]]);
+
+        return $subject->render()['html'];
+    }
+}


### PR DESCRIPTION
Two silent data-loss bugs in the same method, `SaveFormToDatabaseFinisher::getFormValues()`.

## Closes #69 — element identifiers containing dots were saved as null

The form framework stores submitted values **by property path**: an element identified as `foo.0.bar` lives in `$values['foo'][0]['bar']`. Core writes them that way (`FormState::setFormValue()` uses `ArrayUtility::setValueByPath(..., '.')`) and reads them back the same way. The finisher looked the identifier up flat, so those elements always missed and were stored as `null` — no warning, no error, and unrecoverable after the fact.

Values are read by property path now, matching how the runtime wrote them. A plain identifier is still looked up flat first, so nothing changes for the usual case.

## Closes #47 — file uploads broke the export

`#47` reports that the export does not work once a form has an upload field. The reported crash is gone, but the same code still had a live gap behind it: when an upload element has the standard `multiple` property set, core changes the data type to an `ObjectStorage` of file references (`PropertyMappingConfiguration.php:78-79`). The finisher only understood a single reference and guarded with `method_exists($upload, 'getOriginalResource')`, which an `ObjectStorage` does not have — so the `value` key was **never written at all**.

Consequences, all silent: the file names were missing from the saved entry, from every export, and from the upload-path enrichment feature. Multiple uploads are stored as a list of names now, and the `value` key is always written so downstream consumers stop reading an undefined index.

## An upload without a file is an empty list, not null

Always writing the `value` key had a consequence worth calling out, because it broke this extension's own consumer. An optional upload left empty wrote `null`, and `UploadPathEnrichmentEventListener::prependWithSubmissionPrefix()` takes a string or an array under `declare(strict_types=1)` — so with `enableUploadPathEnrichment` switched on, submitting a form with an empty upload field ended in a type error. That happens while the finisher dispatches its event, before the entry is written, and the form runtime does not catch it: HTTP 500 and the submission lost.

An empty upload yields `[]` now, and the listener skips any value that is neither a string nor an array, so a value replaced by a third-party listener on `ManipulateFormValuesEvent` cannot break it either.

## Tests

- `Tests/Unit/Domain/Finishers/FormValueExtractionTest.php` — plain identifiers, dotted paths, missing paths and segments, array values, single and multiple uploads, both empty cases, both upload element types, elements spread over several pages, and the honeypot exclusion.
- `Tests/Unit/EventListener/UploadPathEnrichmentEventListenerTest.php` — the listener prefixes a single name and a list, and leaves a value it cannot prefix alone.
- `Tests/Unit/Form/FormAnswersJsonElementTest.php` — the record view renders an entry that carries no usable text for a field, and escapes both halves.

The suite goes from 7 tests to 41. These are the first tests for logic rather than generated getters, and all three fixes are the kind that regress invisibly.

## Verification

Verified end-to-end on TYPO3 14.3.6 (PHP 8.4) with real frontend submissions, with the upload path enrichment switched on.

| | master | this branch |
|---|---|---|
| multi-file upload | no `value` key at all | both file names, with their paths |
| `container.0.street` | `null` | the submitted value |
| upload left empty | — | HTTP 200, `"value": []` (HTTP 500 before the last commit) |

Downstream: the backend list and the record detail view render all three shapes, the XLSX and CSV exports write the joined names and leave the empty ones empty, and the XML export stays well-formed.

The last two commits are separate from the three fixes above and both concern the record view. It read the `value` key unguarded, so an entry saved by an older version — which is exactly what an upload field produced before this PR — logged a warning and a `htmlspecialchars(null)` deprecation for every affected field when opened. Hardening only that half then left the label behind: `ManipulateFormValuesEvent` documents it as `mixed`, and a label that is not a string reached `htmlspecialchars()`, where an array is a type error. Both go through the same conversion now.

Gates: PHPUnit 41 tests, PHPStan level 6 clean, php-cs-fixer clean.