### PR TITLE
[TASK] Bring the remove screen up to the rest of the module (#34)

### DIFF
--- a/Classes/Controller/FormEntryController.php
+++ b/Classes/Controller/FormEntryController.php
@@ -24,6 +24,7 @@ use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Imaging\IconSize;
 use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
@@ -61,6 +62,7 @@ class FormEntryController extends ActionController
         protected readonly PageRepository $pageRepository,
         protected readonly PersistenceManager $persistenceManager,
         protected readonly ConnectionPool $connectionPool,
+        protected readonly PageRenderer $pageRenderer,
     ) {}
 
     protected function initializeAction(): void
@@ -69,6 +71,12 @@ class FormEntryController extends ActionController
         $parsedBody = $this->request->getParsedBody();
 
         $this->pid = (int)($queryParams['id'] ?? (is_array($parsedBody) ? ($parsedBody['id'] ?? 0) : 0));
+
+        // The delete links ask before they act, and the class that does it is
+        // only bound once this module is loaded. Core pulls it in on its own
+        // through other modules, but not for a reason that has anything to do
+        // with confirmations, so ask for it here.
+        $this->pageRenderer->loadJavaScriptModule('@typo3/backend/modal.js');
     }
 
     /**
@@ -324,7 +332,7 @@ class FormEntryController extends ActionController
             $this->addFlashMessage(
                 LocalizationUtility::translate(
                     'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:flashmessage.deleteFormName.body',
-                    'FrpFormAnswers',
+                    null,
                     [$formName, $this->pid],
                 ) ?? '',
                 LocalizationUtility::translate(

--- a/Classes/Controller/FormEntryController.php
+++ b/Classes/Controller/FormEntryController.php
@@ -147,8 +147,12 @@ class FormEntryController extends ActionController
 
         if ($entry === null) {
             $this->addFlashMessage(
-                'The requested entry could not be found.',
-                'Entry not found',
+                LocalizationUtility::translate(
+                    'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:flashmessage.entryNotFound.body',
+                ) ?? '',
+                LocalizationUtility::translate(
+                    'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:flashmessage.entryNotFound.header',
+                ) ?? '',
                 ContextualFeedbackSeverity::WARNING,
                 true,
             );
@@ -160,8 +164,14 @@ class FormEntryController extends ActionController
         $this->persistenceManager->persistAll();
 
         $this->addFlashMessage(
-            'Deleted entry with uid: ' . $uid,
-            'Entry deleted',
+            LocalizationUtility::translate(
+                'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:flashmessage.removeEntry.body',
+                null,
+                [$uid],
+            ) ?? '',
+            LocalizationUtility::translate(
+                'LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:flashmessage.removeEntry.header',
+            ) ?? '',
             ContextualFeedbackSeverity::OK,
             true,
         );

--- a/Classes/ViewHelpers/Be/TableViewHelper.php
+++ b/Classes/ViewHelpers/Be/TableViewHelper.php
@@ -240,8 +240,10 @@ final class TableViewHelper extends AbstractViewHelper
             // Same confirmation the backend puts on its own delete buttons -
             // the link deletes as soon as it is followed
             $output .= '<a href="' . $this->escape($deleteUri) . '" class="btn btn-default btn-sm t3js-modal-trigger"'
+                . ' data-severity="warning"'
                 . ' data-title="' . $this->escape($this->translate('removeEntry.confirmation.title')) . '"'
-                . ' data-content="' . $this->escape($this->translate('removeEntry.confirmation.content')) . '">'
+                . ' data-content="' . $this->escape($this->translate('removeEntry.confirmation.content')) . '"'
+                . ' data-button-close-text="' . $this->escape($this->translateCore('cancel')) . '">'
                 . $trashIcon . '</a>';
             $output .= '</td>';
 
@@ -343,6 +345,17 @@ final class TableViewHelper extends AbstractViewHelper
         $rawValue = (string)($value ?? '');
 
         return BackendUtility::getProcessedValue($table, $column, $rawValue) ?? $rawValue;
+    }
+
+    /**
+     * A label of the backend itself, so that the buttons of a dialog read the
+     * same here as everywhere else.
+     */
+    private function translateCore(string $key): string
+    {
+        return LocalizationUtility::translate(
+            'LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:' . $key,
+        ) ?? $key;
     }
 
     /**

--- a/Classes/ViewHelpers/Be/TableViewHelper.php
+++ b/Classes/ViewHelpers/Be/TableViewHelper.php
@@ -237,7 +237,12 @@ final class TableViewHelper extends AbstractViewHelper
 
             $output .= '<td>';
             $output .= '<a href="' . $this->escape($editUri) . '" class="btn btn-default btn-sm">' . $pencilIcon . '</a>';
-            $output .= '<a href="' . $this->escape($deleteUri) . '" class="btn btn-default btn-sm">' . $trashIcon . '</a>';
+            // Same confirmation the backend puts on its own delete buttons -
+            // the link deletes as soon as it is followed
+            $output .= '<a href="' . $this->escape($deleteUri) . '" class="btn btn-default btn-sm t3js-modal-trigger"'
+                . ' data-title="' . $this->escape($this->translate('removeEntry.confirmation.title')) . '"'
+                . ' data-content="' . $this->escape($this->translate('removeEntry.confirmation.content')) . '">'
+                . $trashIcon . '</a>';
             $output .= '</td>';
 
             $output .= '</tr>';

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -64,12 +64,40 @@
 				<target>Wollen Sie wirklich alle Einträge dieser Tabelle löschen?</target>
 			</trans-unit>
 			<trans-unit id="countDeletedEntries">
-				<source>There are %s deleted entries to remove</source>
-				<target>Es gibt %s gelöschte Einträge, die Sie entfernen können.</target>
+				<source>Deleted entries on this page: %s</source>
+				<target>Gelöschte Einträge auf dieser Seite: %s</target>
 			</trans-unit>
 			<trans-unit id="removeDeletedEntries">
 				<source>Ultimate delete form entries</source>
 				<target>Einträge endgültig löschen</target>
+			</trans-unit>
+			<trans-unit id="tx_frpformanswers_backend_templates_formentry_prepareremove.h1">
+				<source>Remove deleted entries</source>
+				<target>Gelöschte Einträge entfernen</target>
+			</trans-unit>
+			<trans-unit id="removeDeletedEntries.warning">
+				<source>Removing them deletes the records for good. They cannot be restored from the recycler afterwards.</source>
+				<target>Beim Entfernen werden die Datensätze endgültig gelöscht. Sie lassen sich danach auch nicht mehr über den Papierkorb wiederherstellen.</target>
+			</trans-unit>
+			<trans-unit id="removeDeletedEntries.nothingToRemove">
+				<source>There is no deleted entry on this page to remove.</source>
+				<target>Auf dieser Seite gibt es keinen gelöschten Eintrag zum Entfernen.</target>
+			</trans-unit>
+			<trans-unit id="removeDeletedEntries.confirmation.title">
+				<source>Really remove the deleted entries</source>
+				<target>Gelöschte Einträge wirklich entfernen</target>
+			</trans-unit>
+			<trans-unit id="removeDeletedEntries.confirmation.content">
+				<source>The entries are deleted for good and cannot be restored. Do you want to continue?</source>
+				<target>Die Einträge werden endgültig gelöscht und lassen sich nicht wiederherstellen. Möchten Sie fortfahren?</target>
+			</trans-unit>
+			<trans-unit id="removeEntry.confirmation.title">
+				<source>Really delete this entry</source>
+				<target>Diesen Eintrag wirklich löschen</target>
+			</trans-unit>
+			<trans-unit id="removeEntry.confirmation.content">
+				<source>Do you really want to delete this entry?</source>
+				<target>Möchten Sie diesen Eintrag wirklich löschen?</target>
 			</trans-unit>
             <trans-unit id="tx_frpformanswers_backend_templates_formentry_prepareexport.selectedentries">
                 <source>Selected entries</source>

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -51,6 +51,22 @@
 				<source>Entries removed</source>
 				<target>Einträge entfernt</target>
 			</trans-unit>
+			<trans-unit id="flashmessage.removeEntry.header">
+				<source>Entry deleted</source>
+				<target>Eintrag gelöscht</target>
+			</trans-unit>
+			<trans-unit id="flashmessage.removeEntry.body">
+				<source>The entry with the uid %s has been deleted.</source>
+				<target>Der Eintrag mit der uid %s wurde gelöscht.</target>
+			</trans-unit>
+			<trans-unit id="flashmessage.entryNotFound.header">
+				<source>Entry not found</source>
+				<target>Eintrag nicht gefunden</target>
+			</trans-unit>
+			<trans-unit id="flashmessage.entryNotFound.body">
+				<source>The requested entry could not be found.</source>
+				<target>Der angeforderte Eintrag konnte nicht gefunden werden.</target>
+			</trans-unit>
 			<trans-unit id="flashmessage.removeEntries.body">
 				<source>The deleted entries on Page %s have been ultimately deleted.</source>
 				<target>Die gelöschten Einträge der Seite %s wurden entgültig entfernt.</target>

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -56,8 +56,8 @@
 				<target>Eintrag gelöscht</target>
 			</trans-unit>
 			<trans-unit id="flashmessage.removeEntry.body">
-				<source>The entry with the uid %s has been deleted.</source>
-				<target>Der Eintrag mit der uid %s wurde gelöscht.</target>
+				<source>The entry with the UID %s has been deleted.</source>
+				<target>Der Eintrag mit der UID %s wurde gelöscht.</target>
 			</trans-unit>
 			<trans-unit id="flashmessage.entryNotFound.header">
 				<source>Entry not found</source>
@@ -96,8 +96,8 @@
 				<target>Beim Entfernen werden die Datensätze endgültig gelöscht. Sie lassen sich danach auch nicht mehr über den Papierkorb wiederherstellen.</target>
 			</trans-unit>
 			<trans-unit id="removeDeletedEntries.nothingToRemove">
-				<source>There is no deleted entry on this page to remove.</source>
-				<target>Auf dieser Seite gibt es keinen gelöschten Eintrag zum Entfernen.</target>
+				<source>There are no deleted entries on this page.</source>
+				<target>Auf dieser Seite gibt es keine gelöschten Einträge.</target>
 			</trans-unit>
 			<trans-unit id="removeDeletedEntries.confirmation.title">
 				<source>Really remove the deleted entries</source>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -43,7 +43,7 @@
 				<source>Entry deleted</source>
 			</trans-unit>
 			<trans-unit id="flashmessage.removeEntry.body">
-				<source>The entry with the uid %s has been deleted.</source>
+				<source>The entry with the UID %s has been deleted.</source>
 			</trans-unit>
 			<trans-unit id="flashmessage.entryNotFound.header">
 				<source>Entry not found</source>
@@ -73,7 +73,7 @@
 				<source>Removing them deletes the records for good. They cannot be restored from the recycler afterwards.</source>
 			</trans-unit>
 			<trans-unit id="removeDeletedEntries.nothingToRemove">
-				<source>There is no deleted entry on this page to remove.</source>
+				<source>There are no deleted entries on this page.</source>
 			</trans-unit>
 			<trans-unit id="removeDeletedEntries.confirmation.title">
 				<source>Really remove the deleted entries</source>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -39,6 +39,18 @@
 			<trans-unit id="flashmessage.removeEntries.header">
 				<source>Entries removed</source>
 			</trans-unit>
+			<trans-unit id="flashmessage.removeEntry.header">
+				<source>Entry deleted</source>
+			</trans-unit>
+			<trans-unit id="flashmessage.removeEntry.body">
+				<source>The entry with the uid %s has been deleted.</source>
+			</trans-unit>
+			<trans-unit id="flashmessage.entryNotFound.header">
+				<source>Entry not found</source>
+			</trans-unit>
+			<trans-unit id="flashmessage.entryNotFound.body">
+				<source>The requested entry could not be found.</source>
+			</trans-unit>
 			<trans-unit id="flashmessage.removeEntries.body">
 				<source>The deleted entries on Page %s have been ultimately deleted.</source>
 			</trans-unit>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -49,10 +49,31 @@
 				<source>Do you really want to delete all form entries with this name?</source>
 			</trans-unit>
 			<trans-unit id="countDeletedEntries">
-				<source>There are %s deleted entries to remove</source>
+				<source>Deleted entries on this page: %s</source>
 			</trans-unit>
 			<trans-unit id="removeDeletedEntries">
 				<source>Ultimate delete form entries</source>
+			</trans-unit>
+			<trans-unit id="tx_frpformanswers_backend_templates_formentry_prepareremove.h1">
+				<source>Remove deleted entries</source>
+			</trans-unit>
+			<trans-unit id="removeDeletedEntries.warning">
+				<source>Removing them deletes the records for good. They cannot be restored from the recycler afterwards.</source>
+			</trans-unit>
+			<trans-unit id="removeDeletedEntries.nothingToRemove">
+				<source>There is no deleted entry on this page to remove.</source>
+			</trans-unit>
+			<trans-unit id="removeDeletedEntries.confirmation.title">
+				<source>Really remove the deleted entries</source>
+			</trans-unit>
+			<trans-unit id="removeDeletedEntries.confirmation.content">
+				<source>The entries are deleted for good and cannot be restored. Do you want to continue?</source>
+			</trans-unit>
+			<trans-unit id="removeEntry.confirmation.title">
+				<source>Really delete this entry</source>
+			</trans-unit>
+			<trans-unit id="removeEntry.confirmation.content">
+				<source>Do you really want to delete this entry?</source>
 			</trans-unit>
             <trans-unit id="tx_frpformanswers_backend_templates_formentry_prepareexport.selectedentries">
                 <source>Selected entries</source>

--- a/Resources/Private/Templates/FormEntry/List.html
+++ b/Resources/Private/Templates/FormEntry/List.html
@@ -13,6 +13,7 @@
 
     <f:variable name="title"><f:translate key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:deleteFormName.confirmation.title"/></f:variable>
     <f:variable name="content"><f:translate key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:deleteFormName.confirmation.content"/></f:variable>
+    <f:variable name="cancel"><f:translate key="LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:cancel"/></f:variable>
 
     <f:for each="{formNames}" as="formName">
         <div class="panel panel-default mb-4">
@@ -44,7 +45,7 @@
                         </div>
                         <div class="col-auto">
                             <f:link.action action="deleteFormname" class="btn btn-danger t3js-modal-trigger"
-                                           arguments="{formName: formName}" data="{title:title,content:content}">
+                                           arguments="{formName: formName}" data="{title:title,content:content,severity:'warning','button-close-text':cancel}">
                                 <core:icon identifier="actions-delete" size="small"/>
                                 <f:translate
                                         key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_show.delete"/>

--- a/Resources/Private/Templates/FormEntry/PrepareRemove.html
+++ b/Resources/Private/Templates/FormEntry/PrepareRemove.html
@@ -1,6 +1,46 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
+      data-namespace-typo3-fluid="true">
 <f:layout name="Module"/>
 
 <f:section name="Content">
-<f:translate key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:countDeletedEntries" arguments="{0: count}" /><br />
-<f:link.action style="font-weight: bold; text-decoration: underline;" action="remove"><f:translate key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:removeDeletedEntries" /></f:link.action>
+    <h1>
+        <f:translate
+                key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:tx_frpformanswers_backend_templates_formentry_prepareremove.h1"/>
+    </h1>
+    <f:flashMessages/>
+
+    <f:if condition="{count}">
+        <f:then>
+            <f:variable name="title"><f:translate key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:removeDeletedEntries.confirmation.title"/></f:variable>
+            <f:variable name="content"><f:translate key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:removeDeletedEntries.confirmation.content"/></f:variable>
+
+            <div class="panel panel-default mb-4">
+                <div class="panel-body">
+                    <div class="callout callout-warning">
+                        <f:translate
+                                key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:countDeletedEntries"
+                                arguments="{0: count}"/>
+                        <br/>
+                        <f:translate
+                                key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:removeDeletedEntries.warning"/>
+                    </div>
+
+                    <f:link.action action="remove" class="btn btn-danger t3js-modal-trigger"
+                                   data="{title:title,content:content}">
+                        <core:icon identifier="actions-delete" size="small"/>
+                        <f:translate
+                                key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:removeDeletedEntries"/>
+                    </f:link.action>
+                </div>
+            </div>
+        </f:then>
+        <f:else>
+            <div class="callout callout-info">
+                <f:translate
+                        key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:removeDeletedEntries.nothingToRemove"/>
+            </div>
+        </f:else>
+    </f:if>
 </f:section>
+</html>

--- a/Resources/Private/Templates/FormEntry/PrepareRemove.html
+++ b/Resources/Private/Templates/FormEntry/PrepareRemove.html
@@ -14,26 +14,23 @@
         <f:then>
             <f:variable name="title"><f:translate key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:removeDeletedEntries.confirmation.title"/></f:variable>
             <f:variable name="content"><f:translate key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:removeDeletedEntries.confirmation.content"/></f:variable>
+            <f:variable name="cancel"><f:translate key="LLL:EXT:core/Resources/Private/Language/locallang_common.xlf:cancel"/></f:variable>
 
-            <div class="panel panel-default mb-4">
-                <div class="panel-body">
-                    <div class="callout callout-warning">
-                        <f:translate
-                                key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:countDeletedEntries"
-                                arguments="{0: count}"/>
-                        <br/>
-                        <f:translate
-                                key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:removeDeletedEntries.warning"/>
-                    </div>
-
-                    <f:link.action action="remove" class="btn btn-danger t3js-modal-trigger"
-                                   data="{title:title,content:content}">
-                        <core:icon identifier="actions-delete" size="small"/>
-                        <f:translate
-                                key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:removeDeletedEntries"/>
-                    </f:link.action>
-                </div>
+            <div class="callout callout-warning">
+                <f:translate
+                        key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:countDeletedEntries"
+                        arguments="{0: count}"/>
+                <br/>
+                <f:translate
+                        key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:removeDeletedEntries.warning"/>
             </div>
+
+            <f:link.action action="remove" class="btn btn-danger t3js-modal-trigger"
+                           data="{title:title,content:content,severity:'warning','button-close-text':cancel}">
+                <core:icon identifier="actions-delete" size="small"/>
+                <f:translate
+                        key="LLL:EXT:frp_form_answers/Resources/Private/Language/locallang_be.xlf:removeDeletedEntries"/>
+            </f:link.action>
         </f:then>
         <f:else>
             <div class="callout callout-info">

--- a/Resources/Private/Templates/FormEntry/Remove.html
+++ b/Resources/Private/Templates/FormEntry/Remove.html
@@ -1,5 +1,0 @@
-<f:layout name="Module"/>
-
-<f:section name="Content">
-    Success!
-</f:section>

--- a/Tests/Unit/Language/LanguageFileTest.php
+++ b/Tests/Unit/Language/LanguageFileTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Frappant\FrpFormAnswers\Tests\Unit\Language;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+/**
+ * The translated files have to stay in step with the ones they translate:
+ * a label added on one side only is invisible until someone switches the
+ * backend language.
+ */
+class LanguageFileTest extends UnitTestCase
+{
+    private const LANGUAGE_PATH = __DIR__ . '/../../../Resources/Private/Language/';
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function translatedFileDataProvider(): array
+    {
+        $pairs = [];
+
+        foreach (glob(self::LANGUAGE_PATH . '*.xlf') ?: [] as $path) {
+            $name = basename($path);
+
+            // The translations are the ones carrying a language prefix
+            if (!preg_match('/^([a-z]{2}(?:_[A-Z]{2})?)\.(.+\.xlf)$/', $name, $matches)) {
+                continue;
+            }
+
+            $pairs[$name] = [$matches[2], $name];
+        }
+
+        return $pairs;
+    }
+
+    #[Test]
+    #[DataProvider('translatedFileDataProvider')]
+    public function aTranslationCarriesTheSameLabelsAsTheFileItTranslates(string $source, string $translation): void
+    {
+        $sourceUnits = $this->readUnits($source);
+        $translatedUnits = $this->readUnits($translation);
+
+        self::assertSame(
+            array_keys($sourceUnits),
+            array_keys($translatedUnits),
+            sprintf('%s and %s do not carry the same labels in the same order.', $source, $translation),
+        );
+
+        foreach ($sourceUnits as $id => $unit) {
+            self::assertSame($unit['source'], $translatedUnits[$id]['source'], sprintf('The source of "%s" differs in %s.', $id, $translation));
+            self::assertNotSame('', $translatedUnits[$id]['target'], sprintf('"%s" is not translated in %s.', $id, $translation));
+            self::assertSame(
+                substr_count($unit['source'], '%s'),
+                substr_count($translatedUnits[$id]['target'], '%s'),
+                sprintf('"%s" in %s does not take the same arguments as its source.', $id, $translation),
+            );
+        }
+    }
+
+    #[Test]
+    #[DataProvider('translatedFileDataProvider')]
+    public function noLabelIsDeclaredTwice(string $source, string $translation): void
+    {
+        foreach ([$source, $translation] as $file) {
+            $ids = array_map(
+                static fn(\SimpleXMLElement $unit): string => (string)$unit['id'],
+                iterator_to_array($this->body($file)->{'trans-unit'}),
+            );
+
+            self::assertSame(array_unique($ids), $ids, sprintf('%s declares a label twice.', $file));
+        }
+    }
+
+    /**
+     * @return array<string, array{source: string, target: string}>
+     */
+    private function readUnits(string $file): array
+    {
+        $units = [];
+        foreach ($this->body($file)->{'trans-unit'} as $unit) {
+            $units[(string)$unit['id']] = [
+                'source' => (string)$unit->source,
+                'target' => (string)($unit->target ?? ''),
+            ];
+        }
+
+        return $units;
+    }
+
+    private function body(string $file): \SimpleXMLElement
+    {
+        $xml = simplexml_load_file(self::LANGUAGE_PATH . $file);
+        self::assertNotFalse($xml, sprintf('%s is not well formed.', $file));
+
+        return $xml->file->body;
+    }
+}


### PR DESCRIPTION
Closes #34.

## The feature was already there

The request is to delete entries from the backend module instead of from the database, plus the question in the last paragraph of the issue: whether these records should be soft-deletable at all, given that logging was kept out of the core over data privacy.

Both are answered by the module as it stands, and I checked each path on TYPO3 14.3.6 rather than reading the code:

- the trash in an entry row soft-deletes that entry,
- **Delete entries** on a form soft-deletes every entry of that form on the page, behind a confirmation,
- **Remove** counts what is soft-deleted on the page and deletes those rows for good — verified in the database, the rows are gone, not flagged.

So there is a path that leaves nothing behind, which is what the privacy question asked for. The JavaScript error reported in the second comment (`Cannot read properties of undefined (reading 'button.cancel')`) is gone as well — that was the TYPO3 10 era `AjaxDataHandler`.

## What was left

The Remove screen never got the styling pass the rest of the module had. It was two lines of text and a link carrying inline `font-weight: bold; text-decoration: underline`, on an otherwise blank page.

More to the point, the module's **only irreversible action was its only unconfirmed one**: deleting one form's entries pops a confirmation, while permanently purging the page ran straight off a plain link. The delete in an entry row had none either.

- The screen has a heading, a callout and a danger button, and states what removing does before it offers to do it.
- Permanent removal and the row delete both ask first, using the same `t3js-modal-trigger` the form delete already uses.
- All three dialogs carry the severity the backend puts on its own delete confirmations, and the button that walks away reads Cancel rather than Close.
- The module loads `@typo3/backend/modal.js` itself. It never did: the class behind `t3js-modal-trigger` was only in the page because `action-dispatcher.js` imports `info-window.js` which imports `modal.js` — a chain with nothing to do with confirmations. If it ever goes, the trigger degrades to an inert css class with no error and both links act on the first click, one of them irreversibly. That is exactly the failure this change exists to prevent, so it should not rest on a transitive import.
- A page with nothing to remove says so instead of offering the button.
- `There are 1 deleted entries to remove` reads as a sentence for one entry now.

New labels are in both the English and the German file; both files carry the same 48 units.

## Verification

Walked the whole flow in the backend on TYPO3 14.3.6: empty state, row delete showing the dialog, **Close** leaving the row alone (checked in the database), **OK** soft-deleting it, the Remove screen picking it up, its confirmation, and the purge.

Beyond the happy path:

- **Page scoping.** With two soft-deleted entries on a subpage and none on the parent, the parent shows the empty state and the subpage reports two. Purging the subpage left the parent's six rows untouched, and the message named the right page.
- **Several forms.** A page with two forms renders a panel and a delete for each; deleting the only entry of one makes that panel disappear and leaves the other alone.
- **German.** With the backend set to German the heading, the count, the warning, both dialogs and the flash message all come out translated, uid substituted. (Close and OK stay English here because the sandbox has no language pack — those are core labels.)

No warnings, deprecations or errors in the TYPO3 log across the whole session.

`Tests/Unit/Language/LanguageFileTest.php` is new: it holds every translated language file against the file it translates — same ids in the same order, same sources, nothing left untranslated, same number of `%s`. Eleven labels were just added to two files by hand, which is the drift it exists to catch; verified it fails when a label is added on one side only.

Also removed: `Resources/Private/Templates/FormEntry/Remove.html`, the template of an action that has only ever redirected.

Gates: PHPUnit 43 tests, PHPStan level 6 clean, php-cs-fixer clean.

## Not in scope

`removeEntryAction()` takes a uid and calls `findByUid()` without checking the entry is on a page the editor may edit, and both delete links are GET requests. Neither is introduced here.