### PR TITLE
[TASK] Name the rest of what 7.1.0 carries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,7 +108,7 @@ Please note that pull requests to the *master* branch will be ignored. Please pu
 
 Changelog
 ---------
-:7.1.0: Works with large data sets, exports honour charset and file name, backend uses the current TYPO3 styling, hardened the form filter in the entry table
+:7.1.0: Works with large data sets, exports honour charset and file name, backend uses the current TYPO3 styling, hardened the form filter in the entry table, stores every submitted value including uploads and dotted identifiers, entries can be deleted and removed from the module
 :7.0.1: Fixed the coding guidelines check and added PHP 8.4 to the test matrix
 :7.0.0: Compatibility to TYPO3 v14, TYPO3 v13 support dropped
 :6.1.1: Security update, remove old packages and update phpspreadsheet to 5.2


### PR DESCRIPTION
The changelog line for 7.1.0 was written before #96 and #97 landed. The tag is being moved to include them, so the line names them too.